### PR TITLE
Rely on gunicorn to run OpenFisca server

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,8 +8,11 @@ test:
     - curl --silent 0.0.0.0:8000 | grep --silent 'mes-aides.gouv.fr'
     - curl --silent 0.0.0.0:2000/variable/parisien | grep --silent openfisca_paris/paris.py
     - "curl --silent 0.0.0.0 -H 'Host: monitor.mes-aides.gouv.fr' | grep --silent $CIRCLE_SHA1"
+    - initctl list > $CIRCLE_ARTIFACTS/service-list.start.txt
     - sudo /opt/mes-aides/update.sh provision
+    - initctl list > $CIRCLE_ARTIFACTS/service-list.post-provision.txt
     - sudo /opt/mes-aides/update.sh deploy
+    - initctl list > $CIRCLE_ARTIFACTS/service-list.post-deploy.txt
 
 deployment:
   metal:

--- a/circle.yml
+++ b/circle.yml
@@ -9,10 +9,16 @@ test:
     - curl --silent 0.0.0.0:2000/variable/parisien | grep --silent openfisca_paris/paris.py
     - "curl --silent 0.0.0.0 -H 'Host: monitor.mes-aides.gouv.fr' | grep --silent $CIRCLE_SHA1"
     - initctl list > $CIRCLE_ARTIFACTS/service-list.start.txt
+    - grep '^openfisca' $CIRCLE_ARTIFACTS/service-list.start.txt > $CIRCLE_ARTIFACTS/openfisca-service.start.txt
     - sudo /opt/mes-aides/update.sh provision
     - initctl list > $CIRCLE_ARTIFACTS/service-list.post-provision.txt
+    - grep '^openfisca' $CIRCLE_ARTIFACTS/service-list.post-provision.txt > $CIRCLE_ARTIFACTS/openfisca-service.post-provision.txt
+    - diff $CIRCLE_ARTIFACTS/openfisca-service.post-provision.txt $CIRCLE_ARTIFACTS/openfisca-service.start.txt
     - sudo /opt/mes-aides/update.sh deploy
     - initctl list > $CIRCLE_ARTIFACTS/service-list.post-deploy.txt
+    - grep '^openfisca' $CIRCLE_ARTIFACTS/service-list.post-deploy.txt > $CIRCLE_ARTIFACTS/openfisca-service.post-deploy.txt
+    - diff $CIRCLE_ARTIFACTS/openfisca-service.post-deploy.txt $CIRCLE_ARTIFACTS/openfisca-service.start.txt
+
 
 deployment:
   metal:

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -153,8 +153,10 @@ file { '/etc/init/openfisca.conf':
 }
 
 service { 'openfisca':
-    ensure  => 'running',
-    require => [ File['/etc/init/openfisca.conf'], User['main'] ],
+    ensure     => 'running',
+    hasrestart => true,
+    require    => [ File['/etc/init/openfisca.conf'], User['main'] ],
+    restart    => 'service openfisca reload'
 }
 
 if find_file("/opt/mes-aides/${instance_name}_use_ssl") or find_file('/opt/mes-aides/use_ssl') {

--- a/modules/mesaides/files/openfisca.conf
+++ b/modules/mesaides/files/openfisca.conf
@@ -7,4 +7,4 @@ setgid main
 
 chdir /home/main/mes-aides-ui/openfisca
 
-exec /home/main/venv/bin/openfisca serve --configuration-file api_config.py
+exec /home/main/venv/bin/gunicorn api --config config.py


### PR DESCRIPTION
This PR enables 0-downtime deployment for OpenFisca server