### PR TITLE
Ensure PM2 update ENVVAR

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -127,7 +127,7 @@ exec { 'prestart mes-aides-ui':
 }
 
 exec { 'startOrReload ma-web':
-    command     => '/usr/bin/pm2 startOrReload /home/main/mes-aides-ui/pm2_config.yaml',
+    command     => '/usr/bin/pm2 startOrReload /home/main/mes-aides-ui/pm2_config.yaml --update-env',
     cwd         => '/home/main/mes-aides-ui',
     environment => ['HOME=/home/main'],
     require     => [ Exec['prestart mes-aides-ui'], Package['pm2'] ],


### PR DESCRIPTION
For prefilling purposes, Mes Aides server will need to source third party tokens in its environment.
As an experiment, I would like to load those tokens via environment variables.

To make upcoming updates seamless, I added a flag to reload environment variables while deploying.