### PR TITLE
Enable Keepalive connections to fix "upstream timed out" errors.

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -166,18 +166,28 @@ cron { 'refresh mes-aides stats':
     user        => 'main',
 }
 
+file { '/etc/nginx/conf.d/upstreams.conf':
+    ensure => file,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '644',
+    source => 'puppet:///modules/mesaides/upstreams.conf',
+}
+
 ::mesaides::nginx_config { 'mes-aides.gouv.fr':
     add_www_subdomain => true,
     is_default        => true,
     nginx_root        => '/home/main/mes-aides-ui',
     require           => [ Exec['startOrReload ma-web'] ],
     use_ssl           => find_file('/opt/mes-aides/use_ssl'),
+    upstream_name     => 'mes_aides',
 }
 
 ::mesaides::nginx_config { "${instance_name}.mes-aides.gouv.fr":
     require        => [ Exec['startOrReload ma-web'] ],
     nginx_root     => '/home/main/mes-aides-ui',
     use_ssl        => find_file("/opt/mes-aides/${instance_name}_use_ssl"),
+    upstream_name  => 'mes_aides',
 }
 
 ::mesaides::monitor { "monitor.${instance_name}.mes-aides.gouv.fr":
@@ -185,13 +195,13 @@ cron { 'refresh mes-aides stats':
 }
 
 ::mesaides::nginx_config { 'monitor.mes-aides.gouv.fr':
-    proxied_endpoint => 'http://localhost:8887',
     require          => ::Mesaides::Monitor["monitor.${instance_name}.mes-aides.gouv.fr"],
+    upstream_name    => 'monitor',
 }
 
 ::mesaides::nginx_config { 'openfisca.mes-aides.gouv.fr':
-    proxied_endpoint => 'http://localhost:2000',
     use_ssl          => find_file("/opt/mes-aides/${instance_name}_use_ssl"),
+    upstream_name    => 'openfisca',
 }
 
 class { 'python':

--- a/modules/mesaides/files/upstreams.conf
+++ b/modules/mesaides/files/upstreams.conf
@@ -1,0 +1,12 @@
+upstream mes_aides {
+    server localhost:8000;
+    keepalive 8;
+}
+
+upstream openfisca {
+    server localhost:2000;
+}
+
+upstream monitor {
+    server localhost:8887;
+}

--- a/modules/mesaides/manifests/monitor.pp
+++ b/modules/mesaides/manifests/monitor.pp
@@ -29,7 +29,7 @@ define mesaides::monitor () {
     }
 
     ::mesaides::nginx_config { $name:
-        proxied_endpoint => 'http://localhost:8887',
         require          => Service['ma-monitor'],
+        upstream_name    => 'monitor',
     }
 }

--- a/modules/mesaides/manifests/nginx_config.pp
+++ b/modules/mesaides/manifests/nginx_config.pp
@@ -2,7 +2,7 @@ define mesaides::nginx_config (
     $is_default = false,
     $use_ssl = false,
     $webroot_path = '/var/www',
-    $proxied_endpoint = 'http://localhost:8000',
+    $upstream_name = 'mes_aides',
     $nginx_root = false,
     $add_www_subdomain = false
 ) {

--- a/modules/mesaides/templates/nginx_config.erb
+++ b/modules/mesaides/templates/nginx_config.erb
@@ -124,12 +124,11 @@ server {
   <% else %>
   location / {
 
-    proxy_set_header X-Real-IP       $remote_addr;
-    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header Host            $http_host;
+    # Enable Keepalive Connections
+    # https://www.nginx.com/blog/tuning-nginx/#keepalive
+    # A number of connections may be defined for each upstream in /etc/nginx/conf.d/upstreams.conf
     proxy_set_header Connection      "";
-
-    proxy_http_version 1.1;
+    proxy_http_version               1.1;
 
     proxy_pass        http://<%= @upstream_name %>;
     proxy_redirect    off;

--- a/modules/mesaides/templates/nginx_config.erb
+++ b/modules/mesaides/templates/nginx_config.erb
@@ -123,6 +123,14 @@ server {
   }
   <% else %>
   location / {
+
+    proxy_set_header X-Real-IP       $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host            $http_host;
+    proxy_set_header Connection      "";
+
+    proxy_http_version 1.1;
+
     proxy_pass        <%= @proxied_endpoint %>;
     proxy_redirect    off;
   }

--- a/modules/mesaides/templates/nginx_config.erb
+++ b/modules/mesaides/templates/nginx_config.erb
@@ -118,7 +118,7 @@ server {
   }
 
   location @default {
-    proxy_pass        <%= @proxied_endpoint %>;
+    proxy_pass        http://<%= @upstream_name %>;
     proxy_redirect    off;
   }
   <% else %>
@@ -131,7 +131,7 @@ server {
 
     proxy_http_version 1.1;
 
-    proxy_pass        <%= @proxied_endpoint %>;
+    proxy_pass        http://<%= @upstream_name %>;
     proxy_redirect    off;
   }
   <% end %>


### PR DESCRIPTION
As explained [here](https://stackoverflow.com/questions/24453388/nginx-reverse-proxy-causing-504-gateway-timeout/36589120#36589120) and [there](https://ma.ttias.be/enable-keepalive-connections-in-nginx-upstream-proxy-configurations/), and in the Nginx [docs](http://nginx.org/en/docs/http/ngx_http_upstream_module.html#keepalive), this should fix the 504 errors. 

We have an average of 50 errors of this type per day.
Maybe we could deploy it, and see what happens after a few days?

```
$ { cat /var/log/nginx/mes-aides.gouv.fr.ssl.error.log /var/log/nginx/mes-aides.gouv.fr.ssl.error.log.[1-9] ; zcat /var/log/nginx/mes-aides.gouv.fr.ssl.error.log.*.gz ; } | grep 'upstream timed out' | grep '/api' | awk '{ print $1 }' | sort | uniq -c
     25 2018/08/15
     60 2018/08/16
     43 2018/08/17
     32 2018/08/18
     28 2018/08/19
     59 2018/08/20
     51 2018/08/21
     54 2018/08/22
     40 2018/08/23
     39 2018/08/24
     23 2018/08/25
     29 2018/08/26
     62 2018/08/27
     62 2018/08/28
     58 2018/08/29
     73 2018/08/30
     61 2018/08/31
     40 2018/09/01
     39 2018/09/02
     60 2018/09/03
     65 2018/09/04
     66 2018/09/05
     75 2018/09/06
     50 2018/09/07
     39 2018/09/08
     43 2018/09/09
     66 2018/09/10
     61 2018/09/11
```