### PR TITLE
Add reverse proxy headers.

### DIFF
--- a/modules/mesaides/templates/nginx_config.erb
+++ b/modules/mesaides/templates/nginx_config.erb
@@ -122,8 +122,10 @@ server {
     # Enable Keepalive Connections
     # https://www.nginx.com/blog/tuning-nginx/#keepalive
     # A number of connections may be defined for each upstream in /etc/nginx/conf.d/upstreams.conf
-    proxy_set_header Connection      "";
-    proxy_http_version               1.1;
+    proxy_set_header Connection        "";
+    proxy_set_header Host              $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version                 1.1;
 
     proxy_pass        http://<%= @upstream_name %>;
     proxy_redirect    off;
@@ -134,8 +136,10 @@ server {
     # Enable Keepalive Connections
     # https://www.nginx.com/blog/tuning-nginx/#keepalive
     # A number of connections may be defined for each upstream in /etc/nginx/conf.d/upstreams.conf
-    proxy_set_header Connection      "";
-    proxy_http_version               1.1;
+    proxy_set_header Connection        "";
+    proxy_set_header Host              $host;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_http_version                 1.1;
 
     proxy_pass        http://<%= @upstream_name %>;
     proxy_redirect    off;


### PR DESCRIPTION
This is related to betagouv/mes-aides-ui#904

On Mes Aides, we are generating the source URL like [this](https://github.com/betagouv/mes-aides-ui/blob/e462e1e35af0f8b93952c465623fba7c56a36b16/backend/controllers/teleservices/index.js#L98-L102):
```
req.protocol + '://' + req.get('host')
```

In production, we obtain this:

```
http://mes_aides
```

This is because the reverse proxy does not transmit the original headers.
I think I still need to [activate `trust proxy`](http://expressjs.com/fr/guide/behind-proxies.html) in Express to make the `X-Forwared-Proto` header work as expected



