### PR TITLE
Install packages from package-lock.json

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/trusty64"
 
   # Guest have 500MB of RAM by default
-  # That is not enough to `npm install`
+  # That is not enough to `npm ci`
   # Upgrading to 3GB
   config.vm.provider :virtualbox do |vb|
     vb.memory = 3072

--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -126,7 +126,7 @@ vcsrepo { '/home/main/mes-aides-ui':
 # Using 'make' and 'g++'
 package { 'build-essential': }
 
-# Currently required - Failure during npm install
+# Currently required - Failure during npm ci
 # mes-aides-ui > betagouv-mes-aides-api > ludwig-api > connect-mongo > mongodb > kerberos
 package { 'libkrb5-dev': }
 
@@ -134,7 +134,7 @@ package { 'libkrb5-dev': }
 package { 'libfontconfig': }
 
 exec { 'install node modules for mes-aides-ui':
-    command     => '/usr/bin/npm install',
+    command     => '/usr/bin/npm ci',
     cwd         => '/home/main/mes-aides-ui',
     environment => ['HOME=/home/main'],
     require     => [ Class['nodejs'], User['main'] ],


### PR DESCRIPTION
`npm install` n'installe pas à partir du `package-lock.json` mais à partir de `package.json` et de nouvelles versions des dépendances peuvent être utilisées. C'est risqué.

J'ai eu des soucis d'installation dans la revue/modification sur #990 et j'ai découvert ce problème.

Une PR similaire a été faite sur mes-aides-ui pour garantir la reproductibilité de l'intégration continue.

cf. https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable