### PR TITLE
Bump Node version.

### DIFF
--- a/manifests/default.pp
+++ b/manifests/default.pp
@@ -75,7 +75,7 @@ include '::mongodb::server'
 
 class { 'nodejs':
     repo_url_suffix => '8.x',
-    nodejs_package_ensure => '8.14.0-1nodesource1',
+    nodejs_package_ensure => '8.15.0-1nodesource1',
 }
 
 package { 'git': }


### PR DESCRIPTION
For an obscure reason, previous version can't be found anymore 😐

You can see the problem in [this CircleCI build](https://circleci.com/gh/betagouv/mes-aides-ops/47)