### PR TITLE
[FIX] spécifie une version de npm pour éviter des conflits de dépendance

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -410,6 +410,7 @@ def usermain(c):
 def node(c):
     c.run("curl --silent --location https://deb.nodesource.com/setup_16.x | bash -")
     c.run("apt-get install --assume-yes nodejs")
+    c.run("npm install -g npm@8.1.2")
     pm2(c)
 
 


### PR DESCRIPTION
## Détails

Sur le repository https://github.com/betagouv/aides-jeunes un conflit de dépendances est présent en cas d'utilisation d'une version de npm supérieure ou égale à `8.11.0`.

Sachant que la version `16.15.1` de node utilise npm version `8.11.0` et afin d'éviter un crash de la production lors de l'installation de node (l'url `https://deb.nodesource.com/setup_16.x` ne permattant pas de cibler une version spécifique) cette PR installe la version `8.1.2` de npm