### PR TITLE
fix: indique la base mongo utilisée lors d'un déploiement

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -518,7 +518,7 @@ def node_refresh(c, application, force=False):
     )
     refreshHash = c.run(f'su - main -c "cd {folder} && git rev-parse HEAD"').stdout
     if force or startHash != refreshHash:
-        envvar = f"NODE_ENV=production MES_AIDES_ROOT_URL=http{'s' if application['https'] else ''}://{ application['domain'] }"
+        envvar = f"NODE_ENV=production MONGODB_URL=mongodb://localhost/db_{application['name'])} MES_AIDES_ROOT_URL=http{'s' if application['https'] else ''}://{ application['domain'] }"
         c.run(f'su - main -c "cd {folder} && npm ci"')
         c.run(f'su - main -c "cd {folder} && {envvar} npm run prestart"')
         node_restart(c, application)


### PR DESCRIPTION
## Détails

Lors d'un déploiement continu la commande `npm run prestart` utilisait toujours la base de donnée de production pour générer des stats