### PR TITLE
Aumgente le max-age de hsts à 1 semaine

### DIFF
--- a/roles/bootstrap/templates/nginx_config.conf.j2
+++ b/roles/bootstrap/templates/nginx_config.conf.j2
@@ -7,7 +7,7 @@
   ssl_certificate_key /etc/letsencrypt/live/{{ service_domain }}/privkey.pem;
   include snippets/ssl_params.conf;
 
-  add_header Strict-Transport-Security "max-age=600; includeSubDomains";
+  add_header Strict-Transport-Security "max-age=604800; includeSubDomains";
 
 {%- endmacro %}
 


### PR DESCRIPTION
## Détails

Nouvelle augmentation du max-age de hsts à 1 semaine (cf [documentation hsts preload](https://hstspreload.org/#deployment-recommendations))

Il faudrait s'assurer après le merge de cette PR et avant de passer le max-age à une valeur supérieur que le traffic du simulateur n'est pas impacté.