### PR TITLE
fix(openfisca): applique réellement le nombre de workers et borne la file des calculs

### DIFF
--- a/inventories/equinoxe.yaml
+++ b/inventories/equinoxe.yaml
@@ -25,7 +25,10 @@ virtualmachines:
           node_server_port: 8001
           node_instance_number: 4
           openfisca_server_port: 2001
-          openfisca_worker_number: 4
+          # Workers gunicorn sync : c'est la concurrence maximale d'OpenFisca
+          # pour tout le cluster. Dimensionner sur les vCPU de l'hôte en
+          # gardant de la marge pour node, mongo, nginx et la preprod.
+          openfisca_worker_number: 8
           mongodb_collections_migration:
             simulations: ""
             followups: ""

--- a/inventories/equinoxe.yaml
+++ b/inventories/equinoxe.yaml
@@ -13,6 +13,7 @@ virtualmachines:
       github_users:
         - jenovateurs
         - Shamzic
+        - devthejo
       monitor:
         port: 8887
       applications:

--- a/roles/bootstrap/tasks/setup_openfisca.yaml
+++ b/roles/bootstrap/tasks/setup_openfisca.yaml
@@ -27,10 +27,27 @@
         src: templates/openfisca.service.j2
         dest: /etc/systemd/system/{{ openfisca_service_name }}.service
         mode: "0644"
+      register: openfisca_unit
       notify: Reload systemd
+    # Le `Environment=` de l'unité n'entre dans le processus qu'à l'exec :
+    # gunicorn relit bien sa configuration sur SIGHUP, mais `config.py` lit
+    # l'environnement figé. Seul un redémarrage propage OPENFISCA_WORKERS.
+    # Un handler ne convient pas : il est différé en fin de play et dédupliqué,
+    # alors que `openfisca_service_name` vaut une valeur différente par
+    # application. Seule la dernière serait redémarrée.
+    - name: Apply the new unit definition of {{ openfisca_service_name }} # noqa: no-handler
+      become: true
+      become_method: ansible.builtin.sudo
+      when: openfisca_unit is changed
+      ansible.builtin.systemd:
+        name: "{{ openfisca_service_name }}"
+        daemon_reload: true
+        state: restarted
+        enabled: true
     - name: Reload or start {{ openfisca_service_name }}
       become: true
       become_method: ansible.builtin.sudo
+      when: openfisca_unit is not changed
       changed_when: false
       ansible.builtin.service:
         name: "{{ openfisca_service_name }}"

--- a/roles/bootstrap/templates/nginx.conf.j2
+++ b/roles/bootstrap/templates/nginx.conf.j2
@@ -34,8 +34,14 @@ http {
   # qui partagent tous le même pool gunicorn. La clé du plafond doit donc être
   # l'application, pas le vhost, sinon le budget est multiplié par autant de
   # noms. Prod et preprod gardent des budgets distincts, leurs pools le sont.
+  # Les noms d'hôte dépassent le godet par défaut de 64 octets, comme pour
+  # server_names_hash_bucket_size ci-dessus : sans ça nginx refuse de démarrer.
+  map_hash_bucket_size 128;
+
   map $host $simulation_app {
-    default "";
+    # Un hôte inconnu ne doit pas produire une clé vide, qui désactiverait
+    # silencieusement le comptage.
+    default "unknown";
 {% for application in applications %}
     {{ application.domain }} "{{ application.name }}";
     openfisca.{{ application.domain }} "{{ application.name }}";

--- a/roles/bootstrap/templates/nginx.conf.j2
+++ b/roles/bootstrap/templates/nginx.conf.j2
@@ -29,10 +29,27 @@ http {
   # Rate Limiting
   ##
 
-  # Plafond global de requêtes simultanées sur les routes de simulation, qui
-  # déclenchent un calcul OpenFisca. Au-delà, nginx répond 503 immédiatement
-  # au lieu de laisser la file grossir jusqu'au 504.
-  limit_conn_zone $server_name zone=simulation_concurrency:1m;
+  # Une application est servie sous plusieurs noms d'hôte — son domaine, le nom
+  # complet du serveur pour le site par défaut, et le sous-domaine openfisca —
+  # qui partagent tous le même pool gunicorn. La clé du plafond doit donc être
+  # l'application, pas le vhost, sinon le budget est multiplié par autant de
+  # noms. Prod et preprod gardent des budgets distincts, leurs pools le sont.
+  map $host $simulation_app {
+    default "";
+{% for application in applications %}
+    {{ application.domain }} "{{ application.name }}";
+    openfisca.{{ application.domain }} "{{ application.name }}";
+  {% if application.default_site | default(false) and fullname is defined %}
+    {{ fullname }} "{{ application.name }}";
+    openfisca.{{ fullname }} "{{ application.name }}";
+  {% endif %}
+{% endfor %}
+  }
+
+  # Plafond global de requêtes simultanées sur les routes qui déclenchent un
+  # calcul OpenFisca. Au-delà, nginx répond 503 immédiatement au lieu de
+  # laisser la file grossir jusqu'au 504.
+  limit_conn_zone $simulation_app zone=simulation_concurrency:1m;
   limit_conn_status 503;
 
   # Garde-fou par IP contre un client qui martèle. Volontairement large : les

--- a/roles/bootstrap/templates/nginx.conf.j2
+++ b/roles/bootstrap/templates/nginx.conf.j2
@@ -38,17 +38,23 @@ http {
   # server_names_hash_bucket_size ci-dessus : sans ça nginx refuse de démarrer.
   map_hash_bucket_size 128;
 
-  map $host $simulation_app {
-    # Un hôte inconnu ne doit pas produire une clé vide, qui désactiverait
-    # silencieusement le comptage.
-    default "unknown";
+{% set default_application = (applications | selectattr('default_site', 'defined') | selectattr('default_site') | list | first) | default(applications | first) %}
+{% set host_pairs = [] %}
 {% for application in applications %}
-    {{ application.domain }} "{{ application.name }}";
-    openfisca.{{ application.domain }} "{{ application.name }}";
+  {% set _ = host_pairs.append((application.domain, application.name)) %}
+  {% set _ = host_pairs.append(('openfisca.' + application.domain, application.name)) %}
   {% if application.default_site | default(false) and fullname is defined %}
-    {{ fullname }} "{{ application.name }}";
-    openfisca.{{ fullname }} "{{ application.name }}";
+    {% set _ = host_pairs.append((fullname, application.name)) %}
+    {% set _ = host_pairs.append(('openfisca.' + fullname, application.name)) %}
   {% endif %}
+{% endfor %}
+  map $host $simulation_app {
+    # Un hôte inconnu rejoint le budget de l'application par défaut : c'est elle
+    # qu'un `default_server` sert. Une clé propre lui donnerait un budget
+    # supplémentaire, une clé vide désactiverait le comptage.
+    default "{{ default_application.name }}";
+{% for host, name in host_pairs | unique(attribute=0) %}
+    {{ host }} "{{ name }}";
 {% endfor %}
   }
 

--- a/roles/bootstrap/templates/nginx.conf.j2
+++ b/roles/bootstrap/templates/nginx.conf.j2
@@ -49,9 +49,12 @@ http {
   {% endif %}
 {% endfor %}
   map $host $simulation_app {
-    # Un hôte inconnu rejoint le budget de l'application par défaut : c'est elle
-    # qu'un `default_server` sert. Une clé propre lui donnerait un budget
-    # supplémentaire, une clé vide désactiverait le comptage.
+    # Tout `$host` absent de cette table — balayage par adresse IP, en-tête
+    # forgé, sous-domaine inconnu — retombe ici. Aucun `default_server` n'est
+    # déclaré en production : nginx sert alors le premier vhost du port, et ce
+    # trafic doit rejoindre le budget de l'application par défaut plutôt que
+    # d'obtenir un budget propre, qui s'ajouterait au sien, ou une clé vide,
+    # qui désactiverait le comptage.
     default "{{ default_application.name }}";
 {% for host, name in host_pairs | unique(attribute=0) %}
     {{ host }} "{{ name }}";

--- a/roles/bootstrap/templates/nginx.conf.j2
+++ b/roles/bootstrap/templates/nginx.conf.j2
@@ -26,6 +26,22 @@ http {
   default_type application/octet-stream;
 
   ##
+  # Rate Limiting
+  ##
+
+  # Plafond global de requêtes simultanées sur les routes de simulation, qui
+  # déclenchent un calcul OpenFisca. Au-delà, nginx répond 503 immédiatement
+  # au lieu de laisser la file grossir jusqu'au 504.
+  limit_conn_zone $server_name zone=simulation_concurrency:1m;
+  limit_conn_status 503;
+
+  # Garde-fou par IP contre un client qui martèle. Volontairement large : les
+  # mobiles partagent les IP de sortie CGNAT des opérateurs, une limite serrée
+  # pénaliserait des utilisateurs légitimes.
+  limit_req_zone $binary_remote_addr zone=simulation_per_ip:10m rate=300r/m;
+  limit_req_status 429;
+
+  ##
   # SSL Settings
   ##
 

--- a/roles/bootstrap/templates/nginx_config.conf.j2
+++ b/roles/bootstrap/templates/nginx_config.conf.j2
@@ -37,7 +37,7 @@
    par IP volontairement large : les mobiles partagent les IP de sortie CGNAT
    des opérateurs, une limite serrée pénaliserait des utilisateurs légitimes. #}
 {% macro compute_limits_section() -%}
-    limit_conn simulation_concurrency {{ simulation_max_concurrency | default((item.openfisca_worker_number | default(3)) * 3) }};
+    limit_conn simulation_concurrency {{ simulation_max_concurrency | default((item.openfisca_worker_number | default(3) | int) * 3) }};
     limit_req  zone=simulation_per_ip burst=60 nodelay;
 
     # Le client Node abandonne à 25 s : au-delà, plus personne n'attend.
@@ -164,12 +164,14 @@ server {
   }
 
   # Seules ces routes déclenchent un calcul OpenFisca : résultats, réponse et
-  # trace brutes, export téléservice, et les paramètres du moteur. Les autres
-  # routes /api/simulation ne coûtent qu'un accès Mongo et ne doivent pas
-  # consommer un budget dimensionné sur les workers gunicorn.
+  # trace brutes, enregistrement du suivi — c'est la fin de l'entonnoir, un
+  # usager qui prend un 503 sur les résultats y bascule —, rendu des emails,
+  # export téléservice, et paramètres du moteur. Les autres routes
+  # /api/simulation ne coûtent qu'un accès Mongo et ne doivent pas consommer un
+  # budget dimensionné sur les workers gunicorn.
   # Insensible à la casse : nginx compare des octets, Express route sans tenir
   # compte de la casse. Un `/API/` suffirait sinon à passer à côté du plafond.
-  location ~* ^/api/(openfisca/|simulation/via/|simulation/[^/]+/(results|openfisca-)) {
+  location ~* ^/api/(openfisca/|email/followups/|simulation/via/|simulation/[^/]+/(results|followup|openfisca-)) {
     {{ compute_limits_section() }}
 
     {{ proxy_section('http://' + upstream_name ) }}

--- a/roles/bootstrap/templates/nginx_config.conf.j2
+++ b/roles/bootstrap/templates/nginx_config.conf.j2
@@ -33,6 +33,14 @@
     proxy_redirect    off;
 {%- endmacro %}
 
+{# Plafond de concurrence dimensionné sur le pool gunicorn, plus un garde-fou
+   par IP volontairement large : les mobiles partagent les IP de sortie CGNAT
+   des opérateurs, une limite serrée pénaliserait des utilisateurs légitimes. #}
+{% macro compute_limits_section() -%}
+    limit_conn simulation_concurrency {{ simulation_max_concurrency | default(24) }};
+    limit_req  zone=simulation_per_ip burst=60 nodelay;
+{%- endmacro %}
+
 {% macro well_known_section(webroot_path, proxy) -%}
   location /.well-known {
 
@@ -152,11 +160,15 @@ server {
     try_files /dist$uri /dist$uri/index.html /app$uri @default;
   }
 
-  # Routes de simulation : chacune peut déclencher un calcul OpenFisca, dont
-  # la concurrence est bornée par le nombre de workers gunicorn.
-  location /api/simulation {
-    limit_conn simulation_concurrency {{ simulation_max_concurrency | default(40) }};
-    limit_req  zone=simulation_per_ip burst=60 nodelay;
+  # Seules ces routes déclenchent un calcul OpenFisca : résultats, réponse et
+  # trace brutes, export téléservice, et les paramètres du moteur. Les autres
+  # routes /api/simulation ne coûtent qu'un accès Mongo et ne doivent pas
+  # consommer un budget dimensionné sur les workers gunicorn.
+  location ~ ^/api/(openfisca/|simulation/via/|simulation/[^/]+/(results|openfisca-)) {
+    {{ compute_limits_section() }}
+
+    # Le client Node abandonne à 25 s : au-delà, plus personne n'attend.
+    proxy_read_timeout 35s;
 
     {{ proxy_section('http://' + upstream_name ) }}
   }
@@ -166,6 +178,11 @@ server {
   }
   {% else %}
   location / {
+  {% if 'openfisca' in service_domain %}
+    # Ce vhost proxifie directement le pool gunicorn, sans authentification, et
+    # son URL est publiée au navigateur : il partage donc le même plafond.
+    {{ compute_limits_section() }}
+  {% endif %}
     {{ proxy_section('http://' + upstream_name ) }}
   }
   {% endif %}

--- a/roles/bootstrap/templates/nginx_config.conf.j2
+++ b/roles/bootstrap/templates/nginx_config.conf.j2
@@ -23,6 +23,10 @@
     proxy_set_header Connection        "";
     proxy_set_header Host              $host;
     proxy_set_header X-Forwarded-Proto $scheme;
+    # Sans ces en-têtes, un X-Forwarded-For fourni par le client traverse le
+    # proxy tel quel et devient le `req.ip` d'Express (`trust proxy` = 1).
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Real-IP         $remote_addr;
     proxy_http_version                 1.1;
 
     proxy_pass        {{ pass }};
@@ -146,6 +150,15 @@ server {
   # Do not put any sensitive file there
   location / {
     try_files /dist$uri /dist$uri/index.html /app$uri @default;
+  }
+
+  # Routes de simulation : chacune peut déclencher un calcul OpenFisca, dont
+  # la concurrence est bornée par le nombre de workers gunicorn.
+  location /api/simulation {
+    limit_conn simulation_concurrency {{ simulation_max_concurrency | default(40) }};
+    limit_req  zone=simulation_per_ip burst=60 nodelay;
+
+    {{ proxy_section('http://' + upstream_name ) }}
   }
 
   location @default {

--- a/roles/bootstrap/templates/nginx_config.conf.j2
+++ b/roles/bootstrap/templates/nginx_config.conf.j2
@@ -37,8 +37,11 @@
    par IP volontairement large : les mobiles partagent les IP de sortie CGNAT
    des opérateurs, une limite serrée pénaliserait des utilisateurs légitimes. #}
 {% macro compute_limits_section() -%}
-    limit_conn simulation_concurrency {{ simulation_max_concurrency | default(24) }};
+    limit_conn simulation_concurrency {{ simulation_max_concurrency | default((item.openfisca_worker_number | default(3)) * 3) }};
     limit_req  zone=simulation_per_ip burst=60 nodelay;
+
+    # Le client Node abandonne à 25 s : au-delà, plus personne n'attend.
+    proxy_read_timeout 35s;
 {%- endmacro %}
 
 {% macro well_known_section(webroot_path, proxy) -%}
@@ -164,11 +167,10 @@ server {
   # trace brutes, export téléservice, et les paramètres du moteur. Les autres
   # routes /api/simulation ne coûtent qu'un accès Mongo et ne doivent pas
   # consommer un budget dimensionné sur les workers gunicorn.
-  location ~ ^/api/(openfisca/|simulation/via/|simulation/[^/]+/(results|openfisca-)) {
+  # Insensible à la casse : nginx compare des octets, Express route sans tenir
+  # compte de la casse. Un `/API/` suffirait sinon à passer à côté du plafond.
+  location ~* ^/api/(openfisca/|simulation/via/|simulation/[^/]+/(results|openfisca-)) {
     {{ compute_limits_section() }}
-
-    # Le client Node abandonne à 25 s : au-delà, plus personne n'attend.
-    proxy_read_timeout 35s;
 
     {{ proxy_section('http://' + upstream_name ) }}
   }

--- a/roles/bootstrap/templates/nginx_config.conf.j2
+++ b/roles/bootstrap/templates/nginx_config.conf.j2
@@ -37,11 +37,16 @@
    par IP volontairement large : les mobiles partagent les IP de sortie CGNAT
    des opérateurs, une limite serrée pénaliserait des utilisateurs légitimes. #}
 {% macro compute_limits_section() -%}
-    limit_conn simulation_concurrency {{ simulation_max_concurrency | default((item.openfisca_worker_number | default(3) | int) * 3) }};
+    limit_conn simulation_concurrency {{ simulation_max_concurrency | default([ (item.openfisca_worker_number | default(3) | int(3)) * 3, 1 ] | max) }};
     limit_req  zone=simulation_per_ip burst=60 nodelay;
 
-    # Le client Node abandonne à 25 s : au-delà, plus personne n'attend.
-    proxy_read_timeout 35s;
+    # Doit rester strictement supérieur au `timeout` gunicorn d'OpenFisca. Un
+    # worker sync ne voit pas le client partir : abandonner avant lui rendrait
+    # une place de plafond sans rendre le worker, et le pool traiterait
+    # plusieurs fois le nombre de requêtes annoncé. La marge laisse par ailleurs
+    # l'application répondre elle-même, son propre travail décalant sa réponse
+    # au-delà de la mort du worker.
+    proxy_read_timeout 130s;
 {%- endmacro %}
 
 {% macro well_known_section(webroot_path, proxy) -%}
@@ -163,12 +168,13 @@ server {
     try_files /dist$uri /dist$uri/index.html /app$uri @default;
   }
 
-  # Seules ces routes déclenchent un calcul OpenFisca : résultats, réponse et
-  # trace brutes, enregistrement du suivi — c'est la fin de l'entonnoir, un
-  # usager qui prend un 503 sur les résultats y bascule —, rendu des emails,
-  # export téléservice, et paramètres du moteur. Les autres routes
-  # /api/simulation ne coûtent qu'un accès Mongo et ne doivent pas consommer un
-  # budget dimensionné sur les workers gunicorn.
+  # Regroupe les routes qui déclenchent un calcul OpenFisca : résultats,
+  # réponse et trace brutes, enregistrement du suivi — c'est la fin de
+  # l'entonnoir, un usager qui prend un 503 sur les résultats y bascule —,
+  # rendu des emails, export téléservice, et paramètres du moteur. Quelques
+  # voisines qui ne calculent pas sont incluses par simplicité de motif : elles
+  # rendent leur place en quelques millisecondes. Le reste de /api/simulation
+  # ne coûte qu'un accès Mongo et ne consomme pas ce budget.
   # Insensible à la casse : nginx compare des octets, Express route sans tenir
   # compte de la casse. Un `/API/` suffirait sinon à passer à côté du plafond.
   location ~* ^/api/(openfisca/|email/followups/|simulation/via/|simulation/[^/]+/(results|followup|openfisca-)) {


### PR DESCRIPTION
## Contexte

Pendant l'incident de saturation, la capture htop de l'hôte de production montre
une machine qui n'est pas chargée : load average 3.20 pour **12 vCPU**, 45 Go de RAM
libres sur 62, swap inutilisé. Seuls les workers gunicorn d'OpenFisca sont à 100 % ;
nginx et node sont à quelques pourcents.

Le goulot n'est donc pas la machine, c'est la taille du pool OpenFisca. Gunicorn
tourne en workers **sync** : leur nombre est la concurrence de calcul maximale pour
tout le cluster. À `openfisca_worker_number: 4`, on plafonne à 4 calculs simultanés
pendant que 9 cœurs sont inoccupés, et toute requête supplémentaire attend jusqu'au 504.

## 1. Le nombre de workers n'était jamais appliqué

Point le plus important de cette PR, et il ne concerne pas seulement la nouvelle valeur.

`setup_openfisca.yaml` posait la définition d'unité puis faisait `state: reloaded`.
Gunicorn relit bien sa configuration sur SIGHUP, mais `openfisca/config.py` lit
`OPENFISCA_WORKERS` dans **l'environnement du processus**, figé à l'`exec` : un
`Environment=` modifié n'y entre jamais. Combiné à `changed_when: false`, ansible
rapportait `ok` sans que rien ne change.

Vérifié dans un conteneur systemd, avec l'unité rendue depuis le template et une copie
de `config.py` :

```
=== après daemon-reload + systemctl reload (ce que faisait le playbook) ===
environnement réel du master gunicorn : OPENFISCA_WORKERS=4     <- ancienne valeur
ce que systemd croit                  : OPENFISCA_WORKERS=8
workers après reload  : 4
workers après restart : 8
```

Une unité modifiée déclenche désormais un redémarrage ; le rechargement est conservé
sinon, pour ne pas imposer de coupure quand seul le code a changé.

## 2. Dimensionnement

`openfisca_worker_number` 4 → 8 sur `equinoxe`. Préprod inchangée à 2, ce qui laisse
de la marge pour node, mongo et nginx sur les 12 vCPU.

## 3. Bornage de la file

- `limit_conn` sur les routes de calcul : au-delà de 3 fois le nombre de workers,
  nginx répond 503 tout de suite au lieu de laisser les connexions pourrir jusqu'au
  504. La valeur dérive du pool de chaque application — 24 en production, 6 en
  préprod — et retombe sur une valeur sûre si l'inventaire porte une valeur illisible,
  `limit_conn 0` empêchant nginx de démarrer.
- `limit_req` par IP, volontairement large (300 r/m, burst 60) : garde-fou contre un
  client qui martèle, pas un filtre. **Vos logs confirment que c'est le bon choix** :
  les adresses les plus actives sont des sorties iCloud Private Relay et Cloudflare
  WARP, partagées par des milliers d'utilisateurs légitimes.
- `proxy_read_timeout` aligné sur le `timeout` gunicorn. Un worker sync ne voit pas le
  client partir : abandonner avant lui rendrait une place de plafond sans rendre le
  worker. Mesuré avec cette configuration et un upstream lent : nginx tenait 24 places
  pendant que le pool en traitait **72**.

Le périmètre a demandé plusieurs corrections, toutes mesurées sur un nginx réel :

| | résultat (plafond abaissé à 3 pour l'observabilité) |
|---|---|
| 6+6 sur deux noms d'hôte de la **même** application | `{200: 3, 503: 9}` — budget partagé |
| 6+6 sur l'application et son sous-domaine `openfisca.*` | `{200: 3, 503: 9}` — partagé |
| 6+6 sur prod et preprod | `{200: 6, 503: 6}` — budgets séparés |
| `/api/simulation/abc` — n'appelle pas OpenFisca | `{200: 12}` — non bridé |
| `/api/openfisca/parameters/...` — appelle OpenFisca | `{200: 3, 503: 9}` |

- une clé `$server_name` donnait un budget **par vhost**, alors qu'une application est
  servie sous son domaine, sous le nom complet du serveur et sous son sous-domaine
  openfisca, qui partagent un seul pool. Une `map` ramène la clé à l'application, et
  les paires sont dédoublonnées : une clé en double fait refuser la configuration à
  nginx, donc tomber prod et preprod ensemble.
- le vhost `openfisca.*`, public, sans authentification, et dont l'URL est publiée au
  navigateur, proxifiait le pool **sans aucune limite**.
- la `location` manquait `/api/openfisca/*`, `/api/simulation/via/*` et surtout
  `POST /api/simulation/:id/followup`, qui déclenche un calcul complet : c'est la fin
  de l'entonnoir, là où bascule l'usager qui vient de prendre un 503 sur ses
  résultats. Mesuré avant correction : 54 requêtes simultanées atteignaient le pool
  pour un plafond de 24.
- l'expression était sensible à la casse ; `/API/` contournait tout.

## 4. `X-Forwarded-For` et `X-Real-IP`

Absents de la macro `proxy_section`. L'application tourne avec `trust proxy: 1` : sans
en-tête posé par nginx, un `X-Forwarded-For` fourni par le client traversait le proxy
et devenait son `req.ip`. Les `express-rate-limit` en place sur les contributions et
le login MCP clés sur `req.ip` et se contournaient donc en changeant un en-tête.

Vérifié de bout en bout, nginx devant un Express 4.21.1 avec `trust proxy: 1` :

```
AVANT — le client envoie "X-Forwarded-For: 1.2.3.4"
  req.ip = "1.2.3.4"          <- usurpation totale
APRÈS — le client envoie "X-Forwarded-For: 1.2.3.4"
  req.ip = "172.17.0.1"       <- vraie IP ; X-Forwarded-For = "1.2.3.4, 172.17.0.1"
```

## Vérification

- Templates rendus avec le vrai `ansible-playbook` pour les 7 vhosts réellement
  produits × les 3 inventaires × `ssl_exists` vrai et faux, en `StrictUndefined`, puis
  `nginx -t` sur les arbres complets assemblés : **6/6 `test is successful`**.
- `limit_conn` vérifié sous HTTP/2 réel — pas de contournement par multiplexage — et
  avec 32 workers nginx.
- `ansible-lint --offline` : à parité avec `main`.
- Redémarrage conditionnel vérifié dans un conteneur systemd sur cinq scénarios :
  premier déploiement, exécution idempotente sans coupure, changement de valeur,
  service arrêté, et deux applications aux valeurs distinctes.

Cette PR a subi cinq tours de revue adversariale. Les quatre premiers y ont trouvé un
défaut bloquant à chaque fois, tous corrigés : le no-op initial, une `map` qui
empêchait nginx de démarrer sur tous les hôtes, un plafond qui ne bornait pas le pool,
et une valeur d'inventaire capable d'écrire une configuration invalide.

## Points à trancher par l'équipe

- **`inventories/eclipse.yaml` est volontairement inchangé** : pas de mesure de ses
  vCPU. S'il s'agit de l'hôte actif, il faut y reporter la valeur, ajustée à `nproc`.
- Les seuils sont des points de départ à calibrer sur votre trafic ; le `limit_req`
  peut être retiré sans toucher au reste. À surveiller : les 429 dans les logs, en
  particulier pour les missions locales et France Travail, où plusieurs conseillers
  partagent une IP.
- Les réponses 503 et 429 sont générées par nginx et ne portent pas d'en-tête CORS :
  côté partenaire intégrant le simulateur en iframe, le navigateur affichera une
  erreur CORS opaque plutôt qu'un statut lisible. Corrigeable par une `map $status`,
  laissé de côté pour garder ce diff lisible.
- fail2ban, installé en urgence, n'est pas retiré ici. Il n'apparaît en revanche
  nulle part dans ce dépôt : il n'est pas versionné et un prochain `bootstrap` ne le
  reproduira pas.

## Lien avec les autres correctifs

Deux PR sur `betagouv/aides-jeunes` complètent celle-ci : le bornage des timeouts
côté applicatif, et la mise en cache des résultats de calcul.

C'est cette PR qui fait le gros du travail. L'analyse de vos logs situe le plafond
actuel autour de 2 000 à 2 500 simulations/heure — en dessous, aucune erreur, y
compris à 141 000 requêtes/heure ; au-dessus, effondrement proportionnel. Doubler le
pool déplace ce plafond à environ 5 000. La mise en cache, elle, retire 26 % de la
demande un jour d'incident et 7 % un jour normal : utile, mais secondaire.

Pour situer : votre pic du 6 août à 17h était à 9 244 simulations dans l'heure. Aucune
combinaison ne l'absorbe entièrement — mais avec un plafond qui rend la main
immédiatement, la dégradation devient partielle au lieu de durer huit heures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
