### PR TITLE
fix(monitor): rétablit le service de supervision sous Node 24

### DIFF
--- a/roles/bootstrap/templates/monitor/monitor-server.mjs
+++ b/roles/bootstrap/templates/monitor/monitor-server.mjs
@@ -1,6 +1,6 @@
 import { createServer } from "http"
 import { execSync } from "child_process"
-import configuration from "./monitor-config.json" assert { type: "json" }
+import configuration from "./monitor-config.json" with { type: "json" }
 
 const services = configuration.applications
 


### PR DESCRIPTION
## Constat

`monitor_service` est **en échec** sur equinoxe, et la page de statut
`monitor.equinoxe.mes-aides.1jeune1solution.beta.gouv.fr` répond **502**.

```
node[3979329]: import configuration from "./monitor-config.json" assert { type: "json" }
                                                                 ^^^^^^
SyntaxError: Unexpected identifier 'assert'
systemd[1]: monitor_service.service: Start request repeated too quickly.
```

## Cause

`assert { type: "json" }` a été retiré de Node 22 au profit de `with { type: "json" }`.
L'hôte est passé en Node 24 le **15 juillet 2025** (`nodejs 24.4.1-1nodesource1`),
mais `monitor-server.mjs` n'a pas changé depuis 2023.

La panne était donc **latente depuis un an** : le service tournait encore sous
un processus démarré avant la montée de version, que plus rien n'avait
redémarré. `setup_monitor.yaml` redémarre le service à chaque exécution
(`state: restarted`, `changed_when: false`) — le premier déploiement venu
l'expose. C'est ce qui s'est produit.

## Correctif

Une ligne : `assert` → `with`, la forme normalisée des attributs d'import.

## Vérification

Reproduction de l'erreur puis validation du correctif sous Node 24 :

```
$ node --version
v24.19.0
$ node old.mjs   # assert
SyntaxError: Unexpected identifier 'assert'
$ node new.mjs   # with
ok 1
```

Le fichier corrigé, lancé avec une config de la même forme que celle générée
par `monitor-config.json.j2`, sert bien la page de statut :

```
$ curl -s -o out.json -w "status=%{http_code}\n" http://127.0.0.1:8887/
status=200
$ head out.json
{
  "diskUsagePercentage": "95",
  "services": [
    { "service": "aides_jeunes (local)", "method": "GET", "url": "http://127.0.0.1:8001", "status": 0 },
```

(les `status: 0` viennent des domaines factices de la config de test, injoignables — comportement attendu de `fetchURLStatus`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)