### PR TITLE
fix(cron): vide les crontabs des utilisateurs de déploiement obsolètes

### DIFF
--- a/roles/bootstrap/defaults/main.yaml
+++ b/roles/bootstrap/defaults/main.yaml
@@ -2,6 +2,10 @@
 instance_name: aides-jeunes
 server_user_name: main
 server_user_group: aides_jeunes
+# Utilisateurs ayant porté le déploiement avant `server_user_name`. Leurs
+# crontabs restent en place et rejouent les mêmes tâches : on les vide.
+legacy_cron_users:
+  - debian
 webroot_path: /var/www
 is_default: false
 challenge_proxy: false

--- a/roles/bootstrap/tasks/setup_cron.yaml
+++ b/roles/bootstrap/tasks/setup_cron.yaml
@@ -4,11 +4,21 @@
     envvar_prefix: NODE_ENV=production MONGODB_URL=mongodb://127.0.0.1/db_{{ item.name }}
     env_file_path: "{{ repository_folder }}/.env"
     wrapper_script_path: "/opt/mes-aides/scripts/sentry_wrapper_cron.sh"
+# Les noms servent à la fois à poser les tâches et à les retirer des crontabs
+# hérités : ils sont définis une seule fois pour que les deux ne divergent pas.
+- name: Set cron job names
+  ansible.builtin.set_fact:
+    cron_names:
+      stats: generate stats for {{ item.name }}
+      emails: send initial survey emails for {{ item.name }}
+      sms: send initial survey sms for {{ item.name }}
+      anonymize: anonymize simulation and followup data collections for {{ item.name }}
+      mongo_stats: Execute generate_mongo_stats.sh monthly {{ item.name }}
 - name: Add a cron job for stats generation
   become: true
   become_user: "{{ server_user_name }}"
   ansible.builtin.cron:
-    name: generate stats for {{ item.name }}
+    name: "{{ cron_names.stats }}"
     minute: "23"
     hour: "2"
     job: (cd {{ repository_folder }} && {{ envvar_prefix }} {{ wrapper_script_path }} {{ env_file_path }} /usr/bin/node ./dist-server/backend/lib/stats)
@@ -16,7 +26,7 @@
   become: true
   become_user: "{{ server_user_name }}"
   ansible.builtin.cron:
-    name: send initial survey emails for {{ item.name }}
+    name: "{{ cron_names.emails }}"
     minute: "8"
     hour: "4"
     job: >-
@@ -28,7 +38,7 @@
   become: true
   become_user: "{{ server_user_name }}"
   ansible.builtin.cron:
-    name: send initial survey sms for {{ item.name }}
+    name: "{{ cron_names.sms }}"
     minute: "8"
     hour: "17"
     job: >-
@@ -40,7 +50,7 @@
   become: true
   become_user: "{{ server_user_name }}"
   ansible.builtin.cron:
-    name: anonymize simulation and followup data collections for {{ item.name }}
+    name: "{{ cron_names.anonymize }}"
     minute: "0"
     hour: "5"
     job: (cd {{ repository_folder }} && {{ envvar_prefix }} {{ wrapper_script_path }} {{ env_file_path }} npm run tools:cleaner)
@@ -48,8 +58,26 @@
   become: true
   become_user: "{{ server_user_name }}"
   ansible.builtin.cron:
-    name: Execute generate_mongo_stats.sh monthly {{ item.name }}
+    name: "{{ cron_names.mongo_stats }}"
     minute: "0"
     hour: "0"
     day: "1"
     job: (cd {{ repository_folder }} && {{ envvar_prefix }} {{ wrapper_script_path }} {{ env_file_path }} npm run tools:generate-mongo-stats)
+# Le crontab d'un ancien utilisateur de déploiement survit au changement de
+# `server_user_name` : personne ne le retire, et il déclenche les mêmes tâches à
+# la même minute que le nouveau. Deux exécutions concurrentes d'un envoi qui
+# sélectionne puis marque ses destinataires sans verrou les servent deux fois.
+- name: Remove the same cron jobs from superseded deployment users
+  become: true
+  ansible.builtin.cron:
+    name: "{{ obsolete_cron.1 }}"
+    user: "{{ obsolete_cron.0 }}"
+    state: absent
+  loop: >-
+    {{ legacy_cron_users
+       | difference([server_user_name])
+       | product(cron_names.values() | list)
+       | list }}
+  loop_control:
+    loop_var: obsolete_cron
+    label: "{{ obsolete_cron.0 }} — {{ obsolete_cron.1 }}"


### PR DESCRIPTION
## Constat

Sur equinoxe, **deux crontabs portent les mêmes dix tâches** :

```
-rw------- 1 debian crontab 3750 2025-04-28   ← 10 lignes actives
-rw------- 1 main   crontab 3766 2026-02-04   ← 10 lignes actives
```

Les deux contiennent les mêmes marqueurs `#Ansible:` et les mêmes horaires, pour la production **et** la préproduction :

| tâche | horaire | présente chez `main` | chez `debian` |
|---|---|---|---|
| génération des statistiques | 02h23 | ✔ | ✔ |
| envoi des courriels de questionnaire | 04h08 | ✔ | ✔ |
| anonymisation des simulations et suivis | 05h00 | ✔ | ✔ |
| statistiques mongo mensuelles | 1er à 00h00 | ✔ | ✔ |
| **envoi des SMS de questionnaire** | **17h08** | ✔ | ✔ |

## Cause

`setup_cron.yaml` pose ses tâches avec `become_user: "{{ server_user_name }}"`, aujourd'hui `main`. Le crontab de l'utilisateur précédent n'est retiré par aucune tâche : il survit au changement et continue de se déclencher.

## Pourquoi ce n'est pas inoffensif

Deux exécutions **séquentielles** ne feraient rien de mal : la sélection exclut les suivis ayant déjà reçu leur message. Mais les deux crontabs déclenchent à la **même minute**, et `sendMultipleInitialSms` (`backend/lib/messaging/sending.ts:171`) lit puis écrit sans verrou :

```ts
const mongooseFollowups = await Followups.find(initialSurveySmsMongooseCriteria())
const followupsToSendSms = await filterInitialSurveySms(mongooseFollowups, limit)
const results = await Promise.all(followupsToSendSms.map(/* … sendSurveyBySms … */))
```

Les deux processus sélectionnent donc la **même liste** avant que l'un ait marqué quoi que ce soit. Conséquences :

- jusqu'à **200 SMS facturés au lieu de 100** par jour, sur une enveloppe annuelle estimée à 6 500 ;
- un même usager **sollicité deux fois** ;
- idem pour les 1 000 courriels de 04h08 ;
- l'anonymisation de 05h00 tourne en double sur les mêmes documents.

## Correctif

Les noms de tâches sont définis **une seule fois**, dans `cron_names`, et servent à la fois à poser les tâches et à les retirer des crontabs hérités — pour que les deux ne puissent pas diverger. Une nouvelle tâche vide les mêmes entrées chez tout utilisateur listé dans `legacy_cron_users` et différent de `server_user_name`.

Le retrait passe par `ansible.builtin.cron` avec `state: absent`, qui s'appuie sur les marqueurs `#Ansible:` déjà présents dans les deux fichiers — vérifiés identiques.

## Vérification

- `ansible-lint --offline` sur les deux fichiers modifiés : **0 violation, 0 avertissement**, profil `production` atteint.
- Les marqueurs `#Ansible:` des dix entrées de `debian` ont été relevés sur la machine et correspondent exactement aux noms rendus.
- Le crontab de `debian` ne contient **que** ces dix tâches : rien d'autre n'y sera perdu.
- `legacy_cron_users | difference([server_user_name])` garantit qu'aucune tâche n'est retirée à l'utilisateur courant, y compris si `debian` redevenait un jour `server_user_name`.

À surveiller au déploiement : le crontab de `main` doit rester **inchangé** (même empreinte), seul celui de `debian` doit se vider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)