### PR TITLE
feat(mongodb): sauvegarde quotidienne vérifiée de la base de production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ production.config.js
 .vagrant
 .venv*
 .idea
+.ansible

--- a/README.md
+++ b/README.md
@@ -106,7 +106,96 @@ In order to setup continuous deployment, you will need to:
 - get the private key (see `ansible_ssh_private_key_file` in inventory)
 - set it up in your Github repository as a secret (see [here](https://github.com/betagouv/aides-jeunes/blob/400ab5f90219141b438388d58cd4f27f8fb0ebd6/.github/workflows/cd.yml#L48))
 
-### Backup mongodb collections
+### Automatic MongoDB backup
+
+The `bootstrap` role installs a scheduled backup of the production database. It is applied
+by `bootstrap.yaml` like the rest of the server configuration — there is nothing to run by
+hand.
+
+Every day at 03:30 a systemd timer runs `mongodb-backup.service`, which dumps each database
+listed in `mongodb_backup_databases` into a single compressed archive under
+`/var/backups/mongodb`, verifies it, then deletes archives older than the retention window.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `mongodb_backup_databases` | `[db_aides_jeunes]` | Databases to dump, one archive each |
+| `mongodb_backup_directory` | `/var/backups/mongodb` | Where archives are kept (`0700`, `root:root`) |
+| `mongodb_backup_host` / `mongodb_backup_port` | `127.0.0.1` / `27017` | Where mongod listens |
+| `mongodb_backup_on_calendar` | `*-*-* 03:30:00` | `OnCalendar=` expression for the timer |
+| `mongodb_backup_retention_days` | `14` | Archives older than this are deleted |
+| `mongodb_backup_min_archive_bytes` | `4096` | Sanity floor below which an archive is rejected |
+
+#### Checking that it works
+
+```bash
+systemctl list-timers mongodb-backup.timer   # when it last ran and when it runs next
+systemctl status mongodb-backup.service      # outcome of the last run
+journalctl -u mongodb-backup.service         # full history
+ls -l /var/backups/mongodb                   # the archives themselves (root only)
+```
+
+A run that fails leaves the service in `failed` state, so `systemctl status` and
+`systemctl list-units --failed` both report it. The script never swallows an error: a dump
+that fails, an archive that is too small, corrupt or truncated all abort the run with a
+non-zero exit code, and the bad archive is deleted rather than kept. Rotation only happens
+after a successful dump, so a run of failures can never eat the archives that are still good.
+
+You can trigger a run at any time with `systemctl start mongodb-backup.service`.
+
+#### Restoring
+
+Archives are plain `mongodump --archive --gzip` files. To inspect one without touching the
+live database, restore it under a different name:
+
+```bash
+mongorestore --gzip \
+  --archive=/var/backups/mongodb/db_aides_jeunes-20260807T033000.archive.gz \
+  --nsFrom='db_aides_jeunes.*' --nsTo='db_aides_jeunes_restore.*'
+```
+
+To restore the database in place, after a bad migration or an accidental deletion —
+this **replaces** the collections present in the archive:
+
+```bash
+systemctl stop mongodb-backup.timer   # avoid backing up the broken state mid-restore
+pm2 stop all                          # as user `main`, so nothing writes during the restore
+mongorestore --gzip --drop \
+  --archive=/var/backups/mongodb/db_aides_jeunes-20260807T033000.archive.gz
+pm2 start all
+systemctl start mongodb-backup.timer
+```
+
+`--drop` drops each collection just before restoring it. Collections created *after* the
+backup are not in the archive and are therefore left untouched — drop them by hand if the
+point is to get back to the exact state of the archive.
+
+#### Limits you need to know about
+
+**A backup on the same machine is not a backup.** These archives sit on the same disk as
+the database they protect. They cover a logical accident — a failed migration, a mistaken
+deletion, a bad `tools:cleaner` run — and nothing else. If the machine is lost, wiped, or
+its disk fails, the backups go with it, and so does the service. Making this a real backup
+means a copy on another machine, ideally another provider: a nightly `rclone` or `restic`
+push to object storage (OVH Object Storage, S3), encrypted client-side with a key that is
+*not* stored on the server, with its own retention and a restore drill. That is a hosting
+decision with a cost attached, so it is deliberately not implemented here — but until it
+exists, the single-machine failure mode is uncovered.
+
+**These archives extend how long personal data is kept.** The database holds personal and
+financial data, and a daily cron anonymises simulations and follow-ups at 05:00. The backups
+are *not* anonymised: an archive taken at 03:30 keeps a copy of everything the 05:00 job
+erases, for the whole retention window. A 14-day retention therefore means personal data
+survives its deletion by up to 14 days. This is a deliberate trade-off between recovery
+ability and data minimisation — it is the team's and the DPO's call, not a technical
+default, and `mongodb_backup_retention_days` is the knob. Whatever value is chosen should be
+reflected in the record of processing activities.
+
+### Migrating mongodb collections between servers
+
+> This is a manual, one-shot migration tool, **not** a backup. An operator triggers it, it
+> only covers the collections named in the inventory, and it deletes its archive from the
+> server afterwards. For the scheduled backup of the whole database, see
+> [Automatic MongoDB backup](#automatic-mongodb-backup) above.
 
 It is possible to dump mongodb collections from a server and restore them on another.
 

--- a/roles/bootstrap/defaults/main.yaml
+++ b/roles/bootstrap/defaults/main.yaml
@@ -14,3 +14,32 @@ node_version: "24"
 # changed_when: "'python3.11' not in python_installed.stdout"
 python_version: "3.11.4"
 python_control_version: "3.11"
+
+# Sauvegarde MongoDB
+# Bases sauvegardées, une archive par base et par exécution. `db_aides_jeunes`
+# est la base de production ; la preprod est reconstruite depuis la prod et
+# n'est pas sauvegardée, la conserver ne ferait qu'élargir l'empreinte de
+# données personnelles.
+mongodb_backup_databases:
+  - db_aides_jeunes
+# Hors de tout arbre servi par nginx et hors du dépôt ops (/opt/mes-aides) :
+# voir le commentaire de setup_mongodb_backup.yaml.
+mongodb_backup_directory: /var/backups/mongodb
+mongodb_backup_host: 127.0.0.1
+mongodb_backup_port: 27017
+# 03h30 : creux de trafic, et aucun autre travail planifié — les stats tournent
+# à 02h23, l'envoi de courriels à 04h08, l'anonymisation à 05h00, certbot à
+# 02h00. La sauvegarde passe donc avant l'anonymisation du jour.
+mongodb_backup_on_calendar: "*-*-* 03:30:00"
+# 14 jours. Le disque n'est pas le facteur limitant (1,7 To libres pour une
+# archive de l'ordre du gigaoctet) ; la contrainte est le RGPD. Les archives ne
+# sont pas anonymisées : elles prolongent d'autant la conservation des données
+# que `tools:cleaner` efface chaque jour à 05h00. 14 jours couvre une erreur
+# logique détectée après une absence prolongée sans conserver un historique que
+# rien ne justifie. À arbitrer avec l'équipe et le DPD.
+mongodb_backup_retention_days: 14
+# Plancher de vraisemblance. mongodump réussit et retourne 0 sur une base
+# inexistante ou vide, en produisant une archive de quelques centaines
+# d'octets : sans ce seuil, une faute de frappe dans le nom d'une base
+# produirait des sauvegardes vides pendant des mois sans un seul signal.
+mongodb_backup_min_archive_bytes: 4096

--- a/roles/bootstrap/tasks/main.yaml
+++ b/roles/bootstrap/tasks/main.yaml
@@ -27,6 +27,10 @@
 - name: Install mongoDB 6.x
   ansible.builtin.include_tasks: install_mongodb.yaml
 
+## Setup MongoDB backup
+- name: Configure MongoDB backup
+  ansible.builtin.include_tasks: setup_mongodb_backup.yaml
+
 ## Setup Let's encrypt / Certbot
 - name: Install and configure certbot
   ansible.builtin.include_tasks: install_certbot.yaml

--- a/roles/bootstrap/tasks/setup_mongodb_backup.yaml
+++ b/roles/bootstrap/tasks/setup_mongodb_backup.yaml
@@ -1,0 +1,50 @@
+---
+- name: Set mongodb backup variables
+  ansible.builtin.set_fact:
+    mongodb_backup_service_name: mongodb-backup
+    mongodb_backup_script_path: /usr/local/sbin/mongodb-backup.sh
+# Le répertoire est délibérément hors de tout arbre servi par nginx
+# (/var/www pour /.well-known, /home/{{ server_user_name }}/*/repository pour
+# les fichiers statiques) et hors du dépôt ops synchronisé dans /opt/mes-aides.
+# 0700 root:root : les archives contiennent la base complète, données
+# personnelles et financières comprises.
+- name: Create MongoDB backup directory
+  ansible.builtin.file:
+    path: "{{ mongodb_backup_directory }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+- name: Install MongoDB backup script
+  ansible.builtin.template:
+    src: templates/mongodb_backup.sh.j2
+    dest: "{{ mongodb_backup_script_path }}"
+    owner: root
+    group: root
+    mode: "0700"
+- name: Setup MongoDB backup service
+  ansible.builtin.template:
+    src: templates/mongodb-backup.service.j2
+    dest: /etc/systemd/system/{{ mongodb_backup_service_name }}.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+- name: Setup MongoDB backup timer
+  ansible.builtin.template:
+    src: templates/mongodb-backup.timer.j2
+    dest: /etc/systemd/system/{{ mongodb_backup_service_name }}.timer
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+# Le gestionnaire de rechargement est différé jusqu'au prochain point de
+# synchronisation : sans ce drapeau, systemd travaillerait sur les anciennes
+# définitions d'unités.
+- name: Reload systemd before enabling the timer
+  ansible.builtin.meta: flush_handlers
+- name: Enable and start MongoDB backup timer
+  ansible.builtin.systemd:
+    name: "{{ mongodb_backup_service_name }}.timer"
+    enabled: true
+    state: started

--- a/roles/bootstrap/templates/mongodb-backup.service.j2
+++ b/roles/bootstrap/templates/mongodb-backup.service.j2
@@ -26,5 +26,6 @@ ProtectKernelTunables=true
 ProtectControlGroups=true
 RestrictSUIDSGID=true
 
-[Install]
-WantedBy=multi-user.target
+# Pas de section [Install] : ce service est déclenché par son timer, et par lui
+# seul. Un `WantedBy=multi-user.target` le rendrait activable, et une sauvegarde
+# partirait alors à chaque démarrage de la machine.

--- a/roles/bootstrap/templates/mongodb-backup.service.j2
+++ b/roles/bootstrap/templates/mongodb-backup.service.j2
@@ -1,0 +1,30 @@
+[Unit]
+Description=Sauvegarde des bases MongoDB de {{ instance_name }}
+Documentation=https://github.com/betagouv/aides-jeunes-ops
+# Ordonnancement seulement, sans Wants= ni Requires= : une sauvegarde ne doit
+# jamais démarrer la base de production. Si mongod est arrêté — panne ou
+# maintenance délibérée —, mongodump échoue et le service passe en `failed`.
+# La panne remonte au lieu d'être absorbée par un redémarrage automatique.
+After=mongod.service
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+UMask=0077
+ExecStart={{ mongodb_backup_script_path }}
+
+# Le service n'a besoin d'écrire que dans le répertoire des sauvegardes. Le
+# reste du système lui est en lecture seule : une erreur de configuration ne
+# peut pas déposer d'archive sous /var/www ni dans un dépôt applicatif.
+ProtectSystem=strict
+ReadWritePaths={{ mongodb_backup_directory }}
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/bootstrap/templates/mongodb-backup.timer.j2
+++ b/roles/bootstrap/templates/mongodb-backup.timer.j2
@@ -1,0 +1,12 @@
+[Unit]
+Description=Déclenche la sauvegarde quotidienne des bases MongoDB de {{ instance_name }}
+
+[Timer]
+OnCalendar={{ mongodb_backup_on_calendar }}
+# Rattrape l'exécution manquée si la machine était éteinte à l'heure prévue.
+Persistent=true
+AccuracySec=1min
+Unit={{ mongodb_backup_service_name }}.service
+
+[Install]
+WantedBy=timers.target

--- a/roles/bootstrap/templates/mongodb_backup.sh.j2
+++ b/roles/bootstrap/templates/mongodb_backup.sh.j2
@@ -1,0 +1,128 @@
+#!/bin/bash
+# MANAGED BY MES AIDES OPS
+# Modifications should be made in templates/mongodb_backup.sh.j2
+
+# Une archive compressée par base et par exécution, vérifiée avant d'être
+# publiée sous son nom définitif, puis rotation des archives expirées.
+#
+# Toute anomalie interrompt le script avec un code non nul : le service systemd
+# passe en `failed`, visible dans `systemctl status` et dans le journal. Aucun
+# repli silencieux — une sauvegarde qu'on croit faite est pire que pas de
+# sauvegarde.
+
+set -euo pipefail
+
+# Les archives contiennent la base complète : données personnelles et
+# financières. Tout ce que ce script crée n'est lisible que par root.
+umask 0077
+
+backup_dir="{{ mongodb_backup_directory }}"
+mongo_host="{{ mongodb_backup_host }}"
+mongo_port="{{ mongodb_backup_port }}"
+retention_days="{{ mongodb_backup_retention_days }}"
+min_archive_bytes="{{ mongodb_backup_min_archive_bytes }}"
+databases=({% for database in mongodb_backup_databases %}"{{ database }}" {% endfor %})
+
+fail() {
+  printf 'ÉCHEC DE LA SAUVEGARDE MONGODB : %s\n' "$1" >&2
+  exit 1
+}
+
+if [ ! -d "$backup_dir" ]; then
+  fail "le répertoire de sauvegarde $backup_dir n'existe pas"
+fi
+
+if [ "$retention_days" -lt 1 ]; then
+  fail "rétention invalide ($retention_days jours) : au moins 1 jour est requis"
+fi
+
+for tool in mongodump mongorestore gzip; do
+  command -v "$tool" >/dev/null ||
+    fail "$tool est introuvable, impossible de sauvegarder ou de vérifier"
+done
+
+# Test sur la concaténation, et non sur le cardinal du tableau : la syntaxe
+# bash du cardinal accole une accolade et un dièse, que Jinja lit comme une
+# ouverture de commentaire — le gabarit ne se rend alors plus du tout.
+if [ -z "${databases[*]}" ]; then
+  fail "aucune base à sauvegarder : mongodb_backup_databases est vide"
+fi
+
+timestamp="$(date +%Y%m%dT%H%M%S)"
+
+# Un arrêt brutal pendant un dump laisse un fichier de travail que rien ne
+# reprendra. La rotation ne le voit pas — elle ne retient que *.archive.gz —,
+# il immobiliserait donc sa taille indéfiniment.
+find "$backup_dir" -maxdepth 1 -type f -name '*.archive.gz.partial' -print -delete
+
+for database in "${databases[@]}"; do
+  final="$backup_dir/$database-$timestamp.archive.gz"
+  # Le fichier de travail reste dans le répertoire fermé (0700) : une archive
+  # partielle n'est jamais visible ailleurs, et le renommage final est atomique
+  # puisqu'il a lieu sur le même système de fichiers. Le suffixe `.partial`
+  # l'exclut de la rotation et de toute restauration accidentelle.
+  partial="$final.partial"
+
+  printf 'Sauvegarde de %s depuis %s:%s\n' "$database" "$mongo_host" "$mongo_port"
+
+  # Aucun identifiant sur la ligne de commande : mongod n'écoute que sur la
+  # boucle locale et n'a pas d'authentification. Ajouter --username/--password
+  # ici les exposerait dans `ps` et dans le journal — passer par --config si
+  # l'authentification est un jour activée.
+  if ! mongodump \
+    --host="$mongo_host" \
+    --port="$mongo_port" \
+    --db="$database" \
+    --gzip \
+    --archive="$partial"; then
+    rm -f "$partial"
+    fail "mongodump a échoué pour $database sur $mongo_host:$mongo_port (cause ci-dessus)"
+  fi
+
+  size="$(stat --format=%s "$partial")"
+  if [ "$size" -lt "$min_archive_bytes" ]; then
+    rm -f "$partial"
+    fail "archive de $database anormalement petite ($size octets, plancher $min_archive_bytes) : base vide, inexistante ou mal nommée ?"
+  fi
+
+  # Relit l'archive entière et contrôle les sommes CRC et les longueurs de
+  # chaque bloc gzip. C'est ce qui attrape une écriture partielle, un disque
+  # plein ou une corruption silencieuse — vérifié : une archive tronquée ou
+  # dont un seul octet a changé est rejetée ici.
+  if ! gzip --test "$partial"; then
+    rm -f "$partial"
+    fail "l'archive de $database est corrompue ou tronquée : elle a été supprimée plutôt que conservée"
+  fi
+
+  # PIÈGE : `mongorestore --dryRun` ne lit *pas* le corps de l'archive. Il
+  # s'arrête au prélude et retourne 0 sur une archive tronquée comme sur une
+  # archive corrompue — d'où le `gzip --test` ci-dessus, qui fait le vrai
+  # travail. Ce contrôle-ci reste utile pour ce qu'il vérifie réellement : que
+  # mongorestore sait ouvrir le fichier et y reconnaître des collections, donc
+  # que l'archive est bien au format attendu par l'outil de restauration.
+  if ! mongorestore \
+    --host="$mongo_host" \
+    --port="$mongo_port" \
+    --gzip \
+    --archive="$partial" \
+    --dryRun; then
+    rm -f "$partial"
+    fail "l'archive de $database n'est pas une archive mongodump exploitable : elle a été supprimée plutôt que conservée"
+  fi
+
+  mv "$partial" "$final"
+  printf 'Archive vérifiée : %s (%s octets)\n' "$final" "$size"
+done
+
+# La rotation n'a lieu qu'après une sauvegarde réussie : une série d'échecs ne
+# doit jamais consommer les archives encore valides.
+printf 'Rotation : suppression des archives de plus de %s jours\n' "$retention_days"
+find "$backup_dir" \
+  -maxdepth 1 \
+  -type f \
+  -name '*.archive.gz' \
+  -mtime "+$((retention_days - 1))" \
+  -print \
+  -delete
+
+printf 'Sauvegarde MongoDB terminée.\n'


### PR DESCRIPTION
## Pourquoi

Il n'existe **aucune sauvegarde automatique** de MongoDB. `roles/mongodb_migration` est un outil de migration d'un serveur à l'autre, invoqué à la main et verrouillé derrière `tags: [never, dump]` : il extrait certaines collections selon une requête de date, les rapatrie sur le poste de l'opérateur, puis **les efface du serveur**. Sa section de README s'appelle « Backup mongodb collections », ce qui laisse croire le contraire — elle est renommée ici.

## Ce que fait cette PR

Un timer systemd déclenche à **03h30** un `mongodump --gzip --archive` de `db_aides_jeunes`, vérifie l'archive, la publie, puis supprime celles de plus de 14 jours.

**Choix de placement** : `setup_mongodb_backup.yaml` dans `roles/bootstrap`, pas un rôle séparé. La convention du dépôt distingue déjà les équipements permanents (`setup_monitor.yaml`, `setup_cron.yaml`, `setup_systemd_journal.yaml`) des outils ponctuels d'opérateur, qui ont leur rôle **et leur playbook**. Une sauvegarde planifiée relève du premier cas. Le format d'archive reste celui de `mongodb_migration`, pour qu'une seule incantation `mongorestore --gzip --archive=` restaure les deux.

`--tags update` (déploiements applicatifs) ne touche pas à ces tâches.

## Rien n'est absorbé en silence

Le script s'arrête en code non nul sur : `mongodump` en échec, archive sous le plancher de vraisemblance, archive corrompue, archive illisible par `mongorestore`. L'archive fautive est supprimée plutôt que conservée, et la rotation n'a lieu **qu'après** un succès — une série d'échecs ne consomme pas les archives encore valides.

**Deux pièges trouvés en testant, pas en raisonnant :**

**`Wants=mongod.service` faisait redémarrer la base de production.** Avec mongod arrêté, la sauvegarde *réussissait* : systemd avait démarré la base derrière elle. Une sauvegarde à 03h30 aurait donc pu relancer MongoDB au milieu d'une maintenance délibérée. Devenu `After=` seul.

**`mongorestore --dryRun` ne vérifie pas l'archive.** Il lit le prélude et s'arrête. Mesuré sur une archive de 427 110 octets :

| archive | `--dryRun` | `gzip -t` |
|---|---|---|
| tronquée à 200 000 o | **code 0** | code 1, « unexpected end of file » |
| 4 octets modifiés au décalage 200 000 | **code 0** | code 1, « crc error » |
| base vide (117 o) | code 0 | code 0 |

C'est `gzip --test` qui fait le travail. `--dryRun` est conservé pour ce qu'il prouve réellement — que l'archive est au format attendu par l'outil de restauration. Le troisième cas, `mongodump` qui **retourne 0 sur une base inexistante**, est attrapé par le plancher de taille. Les trois contrôles sont nécessaires, aucun n'est redondant.

## Non-exposition des archives

Relevé exhaustif des directives servant du fichier : **aucun `alias`, aucun `autoindex`, aucun dav**. Exactement deux `root` :

1. `root /var/www`, uniquement dans `location /.well-known` — confiné à `/var/www/.well-known/`.
2. `root /home/main/<app>/repository` — tous les consommateurs préfixent `/dist` ou `/app` (`try_files /dist$uri …`, `try_files /dist$uri =404`).

Les vhosts `monitor` et `openfisca` n'ont pas de racine, ce sont de purs `proxy_pass`. `/var/backups/mongodb` n'est sous aucune de ces racines, ni sous aucun de leurs parents.

```
drwxr-xr-x root root /
drwxr-xr-x root root var
drwxr-xr-x root root backups
drwx------ root root mongodb
-rw------- root root db_aides_jeunes-....archive.gz
```

`www-data`, `main` et `nobody` obtiennent `Permission denied` en lecture comme en listage. Le script lui-même est en 0700.

**Défense en profondeur** : `ProtectSystem=strict` avec `ReadWritePaths` limité au seul répertoire de sauvegarde. Écrire une archive dans `/var/www/html`, `/opt/mes-aides`, `/root`, `/etc` ou même `/var/backups` échoue en « Read-only file system ». Une erreur de configuration future ne peut pas déposer d'archive dans un arbre servi.

Le fichier de travail porte le suffixe `.partial` **dans le répertoire fermé** — pas dans `/tmp` comme le fait `mongodb_migration` — et sa publication est un `rename` atomique sur le même système de fichiers : à aucun instant une archive partielle ou aux mauvais droits n'est visible.

## Preuves

Conteneur Debian 12, systemd en PID 1, MongoDB 7.0.39 installé depuis le même dépôt que `install_mongodb.yaml`, `ansible-playbook --connection=local`.

- **Idempotence** : `ok=9 changed=5` à froid, `ok=8 changed=0` au second passage. `systemd-analyze verify` propre. Timer armé : `Sat 2026-08-08 03:30:00`.
- **Sauvegarde** : 28 000 documents → archive de 287 539 octets, `-rw------- root root`.
- **Restauration** : `28000 document(s) restored successfully. 0 failures`, décomptes conformes (20000/8000), et **`dbHash` identique** sur les deux collections — le contenu est identique, pas seulement le nombre.
- **Échecs** : mongod arrêté, base mal nommée, corruption injectée en cours d'exécution, liste de bases vide — tous en code 1, service `failed`, message explicite, archive fautive supprimée, anciennes archives intactes.
- **Rotation** avec des fichiers antidatés : supprime J-14, J-15, J-30 ; conserve J-13, J-5, J-1 ; ne touche ni `note.txt` ni un `.partial`. Ce test a révélé qu'un `.partial` orphelin (coupure brutale) n'était jamais récupéré — un balayage a été ajouté en début d'exécution.
- **`ansible-lint --offline`** : 0 échec, 0 avertissement, profil `production`.

## ⚠️ Le manque le plus important : rien ne signale un échec

Un échec est visible dans `systemctl status`, `systemctl list-units --failed` et le journal — mais **rien ne le pousse à personne**. C'est exactement ainsi que `monitor_service` est resté en échec sans que quiconque le voie, jusqu'à ce qu'on le cherche.

Une sauvegarde qui échoue en silence pendant un mois est le mode de défaillance qui fait vraiment mal, et il n'est pas couvert ici. La suite logique : un `OnFailure=` relié à Sentry, dont ce dépôt a déjà le nécessaire avec `scripts/sentry_wrapper_cron.sh`. Je ne l'ai pas fait dans cette PR parce qu'il faut décider comment une unité systemd exécutée en root accède au DSN sans lire un `.env` applicatif — ça mérite sa propre discussion. **À traiter rapidement.**

## Deux décisions qui vous appartiennent

**Une sauvegarde sur la même machine n'est pas une sauvegarde.** Ces archives partagent le disque de la base. Elles couvrent une migration ratée, une suppression accidentelle, un `tools:cleaner` défectueux — rien d'autre. Si la machine est perdue, tout l'est en même temps. Il faudrait une copie ailleurs, idéalement chez un autre hébergeur, **chiffrée avec une clé qui ne réside pas sur le serveur**, avec sa propre rétention et un exercice de restauration périodique. Non implémenté : ça engage un coût et un choix d'hébergement.

**RGPD.** `tools:cleaner` anonymise chaque jour à 05h00 ; l'archive de 03h30 capture donc, non anonymisé, tout ce que ce travail effacera 90 minutes plus tard. Une rétention de N jours prolonge d'autant la conservation effective. J'ai retenu **14 jours** au titre de la minimisation, pas de la capacité : le disque en autoriserait 90 (14 archives ≈ 6 à 14 Go pour 1 700 Go libres, moins de 1 %). Ça relève du registre des traitements, et `mongodb_backup_retention_days` est le seul bouton si le DPD veut 7.

## Un défaut signalé, non corrigé ici

`roles/mongodb_migration/tasks/mongodb-dump.yaml` crée `/tmp/mongodump` en **0755** et y écrit les archives de `simulations` et `followups`. Pendant le dump et le rapatriement, **tout utilisateur local peut lire les données personnelles et financières** de toutes les simulations de la fenêtre. Sur une machine où `main` exécute du code applicatif, ce n'est pas théorique. Le correctif tient en trois lignes, mais c'est un autre sujet : dites-moi si vous préférez qu'il voyage avec cette PR.

## Ce qui n'a pas pu être vérifié

- **Rien n'a été exécuté sur la production.** Tout ci-dessus vient d'un conteneur.
- **La taille réelle et le taux de compression** : les données de test sont synthétiques et répétitives. La première exécution réelle les donnera.
- **La durée du dump et son effet sur la production.** 3 Go plus une relecture complète par `gzip -t` prendront quelques minutes d'E/S et de CPU. Et `mongodump` sans `--oplog` sur une instance isolée donne un instantané **non cohérent dans le temps** : les collections sont extraites l'une après l'autre. Acceptable à 03h30 pour cette charge, et incorrigeable sans jeu de réplicas — mais il faut le savoir.
- **Le disque plein** : le plancher de taille et `gzip -t` devraient attraper une écriture tronquée, ce n'a pas été prouvé en remplissant un disque.

🤖 Generated with [Claude Code](https://claude.com/claude-code)