### PR TITLE
fix(mongodb): ferme les archives de migration aux autres utilisateurs

### DIFF
--- a/roles/mongodb_migration/tasks/mongodb-dump.yaml
+++ b/roles/mongodb_migration/tasks/mongodb-dump.yaml
@@ -1,11 +1,17 @@
 ---
+# Les archives contiennent des simulations et des suivis : données personnelles
+# et financières. Le répertoire est fermé et l'umask du dump l'est aussi, sans
+# quoi tout utilisateur local pourrait les lire le temps du transfert.
 - name: Create MongoDB dump directory
   ansible.builtin.file:
     path: /tmp/mongodump
     state: directory
-    mode: "0755"
+    owner: root
+    group: root
+    mode: "0700"
 - name: Dump MongoDB database with a query
   ansible.builtin.shell: |
+    umask 0077
     mongodump \
       --db db_{{ application.name }} \
       --collection {{ item.key }} \
@@ -14,6 +20,13 @@
       --gzip
   register: dump_result
   changed_when: dump_result.rc == 0
+  with_dict: "{{ application.mongodb_collections_migration }}"
+- name: Restrict MongoDB dump archives to root
+  ansible.builtin.file:
+    path: /tmp/mongodump/{{ application.name }}_{{ item.key }}.gz
+    owner: root
+    group: root
+    mode: "0600"
   with_dict: "{{ application.mongodb_collections_migration }}"
 - name: Fetch MongoDB dump to local machine
   ansible.builtin.fetch:


### PR DESCRIPTION
## Constat

`roles/mongodb_migration/tasks/mongodb-dump.yaml` crée `/tmp/mongodump` en **0755**, et `mongodump` y écrit ses archives avec l'umask par défaut, typiquement **0644**.

Ces archives contiennent les collections `simulations` et `followups` de la fenêtre demandée : **données personnelles et financières**. Pendant toute la durée du dump puis du rapatriement, n'importe quel utilisateur local peut les lire.

Sur equinoxe, où l'application s'exécute sous son propre utilisateur et où plusieurs services cohabitent, ce n'est pas une hypothèse d'école.

## Correctif

- répertoire en **0700 root:root** ;
- dump exécuté sous **`umask 0077`** — sans quoi l'archive naîtrait en 0644 et serait lisible pendant l'instant qui sépare sa création de tout `chmod` ultérieur ;
- archives explicitement ramenées en **0600 root:root** avant le transfert, pour couvrir le cas d'un répertoire préexistant aux mauvais droits.

Les trois sont nécessaires : l'umask seul ne protège pas un répertoire déjà créé en 0755 par une exécution précédente, et un `chmod` postérieur laisse une fenêtre ouverte.

## Périmètre

Aucun changement de comportement : mêmes archives, même emplacement, même rapatriement, même suppression en fin de course. Seuls les droits changent.

Ce rôle est verrouillé derrière `tags: [never, dump]` : il ne s'exécute que sur invocation explicite d'un opérateur, jamais pendant un déploiement.

## Vérification

`ansible-lint --offline` sur le fichier modifié : **0 échec, 0 avertissement**, profil `production`.

## Origine

Défaut relevé en préparant #240, qui met en place une sauvegarde automatique. Les deux sont indépendants — celle-ci corrige l'outil de migration existant, #240 ajoute une sauvegarde planifiée qui, elle, écrit directement dans un répertoire fermé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)