### PR TITLE
fix(cron): retire le DSN Sentry des journaux et de la charge utile

### DIFF
--- a/scripts/sentry_wrapper_cron.sh
+++ b/scripts/sentry_wrapper_cron.sh
@@ -18,8 +18,6 @@ if [ -z "$SENTRY_CRON_DSN" ]; then
     exit 1
 fi
 
-echo "SENTRY_CRON_DSN is set to: $SENTRY_CRON_DSN"
-
 # The wrapped command is executed and the result status is stored
 COMMAND="$@"
 OUTPUT=$(eval "$COMMAND" 2>&1)
@@ -28,7 +26,9 @@ STATUS=$?
 if [ $STATUS -ne 0 ]; then
     echo "Cron job failed: $COMMAND"
     echo "Error output: $OUTPUT"
-    SENTRY_DSN="$SENTRY_CRON_DSN" sentry-cli send-event -m "Cron job failed: $COMMAND | Error: $OUTPUT"
+    # --no-environ: sentry-cli attaches the process environment to the event by
+    # default, and this script has just sourced an application .env.
+    SENTRY_DSN="$SENTRY_CRON_DSN" sentry-cli send-event --no-environ -m "Cron job failed: $COMMAND | Error: $OUTPUT"
 fi
 
 exit $STATUS


### PR DESCRIPTION
## Constat

`scripts/sentry_wrapper_cron.sh` divulgue le DSN Sentry, de deux façons distinctes.

**1. Il l'imprime à chaque exécution.** Vérifié dans les journaux de production :

```
[Sentry] SENTRY_CRON_DSN is set to: https://74d0…@sentry.incubateur.net/173
```

Cette ligne part dans les journaux pm2, dans le courriel de cron, et dans tout ce qui collecte la sortie. Elle est répétée à chaque passage — l'enveloppe est appelée par **dix tâches cron quotidiennes**.

**2. Il joint tout l'environnement à l'événement.** Sans `--no-environ`, `sentry-cli` attache le contenu de l'environnement du processus sous `extra.environ`. Or ce script vient précisément de sourcer un `.env` applicatif : la capture d'un événement réel contient `SENTRY_DSN` et `MONGODB_URL`.

## Portée

Un DSN Sentry n'ouvre pas l'accès en lecture au projet, mais il autorise **l'écriture** : quiconque le détient peut injecter des événements, noyer les vraies alertes et consommer le quota. C'est précisément le canal par lequel l'équipe apprend qu'une tâche a échoué.

Et le second point est plus large que le DSN : `extra.environ` embarque ce que le `.env` chargé contient, quel qu'il soit.

## Correctif

Deux lignes : suppression de l'`echo`, ajout de `--no-environ`.

Aucun changement de comportement par ailleurs — même déclenchement, même message, même code de sortie propagé.

## À faire de votre côté

Le DSN a circulé en clair dans les journaux pendant longtemps. **Une rotation est prudente** : elle se fait côté Sentry, et la nouvelle valeur doit être reportée dans les `.env` applicatifs. Ce correctif empêche la fuite de continuer, il n'annule pas celle qui a eu lieu.

## Origine

Défaut relevé en construisant le mécanisme d'alerte sur les unités systemd en échec, qui devait s'appuyer sur cette même enveloppe. Les deux sont indépendants : celui-ci est isolé pour pouvoir partir seul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)