### PR TITLE
feat(alerting): signale à Sentry les unités systemd en échec

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,10 @@ reflected in the record of processing activities.
 A backup that fails silently for a month is the failure mode that actually hurts, and the
 status page itself sat in `failed` for a year without anyone noticing. The `bootstrap` role
 therefore makes a broken unit announce itself, through the Sentry project the cron jobs
-already report to. Nothing to run by hand — `bootstrap.yaml` installs it.
+already report to. `bootstrap.yaml` installs the whole thing, but it needs **one value from
+you**: `alerting_dsn_destination`, in the inventory. Until that is set the units are
+installed and inert, and the play says so with a red task — see
+[the one manual step](#the-one-manual-step) below.
 
 Two triggers, because they catch different things:
 
@@ -368,6 +371,12 @@ sweep at the default cap can take five minutes before failing.
 But a sweep whose timer has been disabled reports nothing at all and says nothing about it;
 the only remaining witness is then the status page, which is why the sweep units are in the
 watched list.
+
+**There is no heartbeat.** Between two deployments nothing exercises the DSN as long as no
+unit fails, so a key revoked on the Sentry side goes unnoticed until the next incident — and
+that incident is then the one that does not arrive. It stays visible locally (unit `failed`,
+status page red), but the push channel is silently gone. A Sentry cron-monitor check-in from
+the daily sweep would close that window; it is not implemented here.
 
 **Nobody is paged.** These events land in Sentry like the cron failures already do, and
 inherit whatever notification rules that project has. If nobody has an alert rule on this

--- a/README.md
+++ b/README.md
@@ -228,9 +228,22 @@ a thought for anything that handles user data.
 | `alerting_watched_units` | backup service + timer, `monitor_service`, `mongod`, `nginx`, the sweep itself | Units getting an `OnFailure=` drop-in; those with `expect_active: true` must also be running |
 | `alerting_sweep_on_calendar` | `*-*-* 08:15:00` | `OnCalendar=` of the daily sweep |
 | `alerting_sweep_max_events` | `10` | Cap on events per sweep, so a machine on fire does not open thirty issues |
+| `alerting_dsn_allowed_hosts` | `[]` | Hosts the DSN may point to; empty means pin-on-first-use (see below) |
 
-Adding a unit is two lines in `alerting_watched_units`. The page on `monitor.<fullname>` also
-publishes the state of these units next to its URL probes.
+Adding a unit is two lines in `alerting_watched_units`. The name must carry its systemd
+suffix — `nginx.service`, not `nginx` — or the drop-in lands in a directory systemd does not
+read and the unit counts twice during the sweep; a check in the role refuses such a list and
+names the offending entries. The page on `monitor.<fullname>` also publishes the state of
+these units next to its URL probes.
+
+**Nothing in this chain is allowed to wait forever.** `sentry-cli` has no timeout option of
+its own, so every call is wrapped in `timeout 30`, and both units carry a `TimeoutStartSec=`.
+Without them, a connection that is accepted and never answered — a stateful firewall, a NAT,
+a saturated ingest — leaves the sweep `activating` indefinitely; systemd then merges the next
+day's trigger into the job already running, and **the alerting stops for good without
+anything ever turning `failed`**. The status page treats a long `activating` as not-ok for
+the same reason: the witness of last resort must not certify that all is well while the chain
+is dead.
 
 #### Where the DSN comes from
 
@@ -267,6 +280,25 @@ step:
 Any one of those would do; all three are there because a shell substitution reaching a root
 unit is not a bug you want to discover in production.
 
+Validating the syntax is not enough, because the DSN also decides **where the alerts go**, and
+they carry the journals of root units the deployment user cannot read. Whoever can write the
+`.env` could therefore both exfiltrate those journals and switch the whole supervision off by
+pointing it at a sink that answers `200` — the self-test included. So the **host** is anchored
+too:
+
+- if `alerting_dsn_allowed_hosts` is set, the host must match one of its patterns
+  (`*.ingest.sentry.io` and the like). Use this as soon as the real host is known;
+- if it is empty — the default — the host is **pinned on first use**: the first run adopts
+  whatever the `.env` says, and any later change of host is refused. The DSN already in place
+  keeps working meanwhile, so the refusal protects the alerting instead of cutting it.
+
+The default is pin-on-first-use rather than a hardcoded list because this repository cannot
+know which Sentry instance the project uses, and a wrong guess would silence production
+alerting on the very day it is deployed. Changing host legitimately means setting
+`alerting_dsn_allowed_hosts`, or deleting `/etc/aides-jeunes/alerting.env` to re-adopt. Only
+the host is pinned: rotating the key, or changing the port or project id, goes through
+untouched.
+
 If the `.env` is not there yet — a brand new machine — or if the DSN is malformed, the play
 prints a warning and carries on rather than blocking the application deployment, and the
 alerting scripts exit non-zero with an explicit message rather than pretending to send
@@ -283,6 +315,11 @@ It does not run on every deployment — one Sentry event per deployment would re
 each time — but it does run whenever something changed, or whenever `alerting.env` is
 missing, which covers every case where the chain can be broken without anyone knowing. The
 event carries the `systemd-alerting-self-test` fingerprint, so it stays in a single issue.
+
+The checks in this role are `assert` tasks with `ignore_errors: true`, not `debug` messages.
+The trade-off is deliberate — a broken alerting chain must not stop the application from
+deploying — but a warning buried in a green wall of output is not a signal. As asserts they
+come out red and show up as `ignored=` in the play recap.
 
 #### Checking that it works
 
@@ -303,9 +340,12 @@ triggers `OnFailure=`, and never shows up in `systemctl --failed`. What catches 
 URL probe on the status page returning 0 or 502 — which is why the two halves of that page
 are complementary and neither replaces the other.
 
-**Sentry is a single point of failure.** If the DSN is wrong, the project is full, or the
-network is down, nothing arrives. The failure is at least loud locally: `sentry-cli` exits
-non-zero, the alerting unit lands in `failed`, and the *next* sweep reports it — verified.
+**Sentry is a single point of failure.** If the DSN is wrong, the project is full, the
+network is down, or the ingest accepts connections without answering, nothing arrives. The
+failure is at least loud locally and bounded in time: `sentry-cli` exits non-zero — 124 when
+its own timeout fires — the alerting unit lands in `failed`, and the *next* sweep reports it
+— verified. A sweep against a host that never answers costs up to 30 s per event, so a full
+sweep at the default cap can take five minutes before failing.
 But a sweep whose timer has been disabled reports nothing at all and says nothing about it;
 the only remaining witness is then the status page, which is why the sweep units are in the
 watched list.

--- a/README.md
+++ b/README.md
@@ -206,14 +206,22 @@ Two triggers, because they catch different things:
 
 Both run the same script, `/usr/local/sbin/alert_systemd_failure.sh`, which sends one Sentry
 event per unit with a fingerprint of `systemd-unit-failure` + the unit name — so a unit gets
-one Sentry issue, not one per day, and closing it means the panne is handled. The last 50
-journal lines of the unit ride along as breadcrumbs, so the alert says *why* without needing
-an SSH session.
+one Sentry issue, not one per day, and closing it means the failure is handled.
 
 The sweep reads `systemctl --failed` in full, not just the list below: a failed unit nobody
 thought to declare — an `*_openfisca` service, something added later — is still reported. The
 list exists for the other half of the job, checking that a unit which should be running
-actually is, which no global query can guess.
+actually is, which no global query can guess. Declared units are examined **first**, before
+the global list, and the event cap only bites on what is left: `systemctl` answers in
+alphabetical order, so a burst of unrelated failures would otherwise eat the whole budget
+before ever reaching `nginx`.
+
+Only **declared** units ship their last 50 journal lines as breadcrumbs, so the alert says
+*why* without needing an SSH session. Anything else is reported without its journal: the
+sweep also covers application and `*_openfisca` services, whose logs can carry personal and
+financial data that has no business being exported to Sentry. **Adding a unit to
+`alerting_watched_units` is therefore also a decision to send its journal to Sentry** — worth
+a thought for anything that handles user data.
 
 | Variable | Default | Purpose |
 | --- | --- | --- |
@@ -227,9 +235,8 @@ publishes the state of these units next to its URL probes.
 #### Where the DSN comes from
 
 The alerting units run as `root`, and a root unit has no business reading an application
-`.env` — that file belongs to the deployment user, so anyone who can write it could inject
-code into a root shell, and it carries every other application secret. The units are hardened
-with `ProtectHome=true` and could not read it anyway.
+`.env` — that file belongs to the deployment user, and it carries every other application
+secret. The units are hardened with `ProtectHome=true` and could not read it anyway.
 
 So ansible, during `bootstrap.yaml`, extracts the single `SENTRY_CRON_DSN` line from the
 default application's `.env` and writes it to `/etc/aides-jeunes/alerting.env`, `0600
@@ -245,9 +252,37 @@ the play without a vault password file on the server — that is, the same serve
 with more machinery. `bootstrap.yaml` replays on every merge to `main`, so rotating
 `SENTRY_CRON_DSN` in the `.env` propagates on the next deployment.
 
-If the `.env` is not there yet — a brand new machine — the play prints a warning and carries
-on, and the alerting scripts exit non-zero with an explicit message rather than pretending to
-send anything.
+The value crosses a privilege boundary — it comes from a file the deployment user owns and
+ends up in a file that root-owned units read — so it is treated as untrusted input at every
+step:
+
+- **it is validated against a character whitelist** (`A-Za-z0-9:/@._~%?=-`) before being
+  written. A `$(…)`, a backtick, a quote or a space is refused outright, with a message that
+  never prints the value;
+- **no script ever `source`s it.** `sync_alerting_dsn.sh` reads the `.env` with `sed`, and
+  `alert_systemd_failure.sh` reads `alerting.env` the same way;
+- **the units get it through `EnvironmentFile=`**, which systemd parses itself, with no shell
+  in the path.
+
+Any one of those would do; all three are there because a shell substitution reaching a root
+unit is not a bug you want to discover in production.
+
+If the `.env` is not there yet — a brand new machine — or if the DSN is malformed, the play
+prints a warning and carries on rather than blocking the application deployment, and the
+alerting scripts exit non-zero with an explicit message rather than pretending to send
+anything.
+
+#### The self-test
+
+An alerting chain that installs "all green" on a machine where nothing will ever be sent
+reproduces exactly the silence it exists to break. So at the end of the role, ansible runs
+`alert_systemd_failure.sh --self-test`, which sends a real `info` event and fails loudly if
+it cannot. The play warns; it does not abort.
+
+It does not run on every deployment — one Sentry event per deployment would reopen a ticket
+each time — but it does run whenever something changed, or whenever `alerting.env` is
+missing, which covers every case where the chain can be broken without anyone knowing. The
+event carries the `systemd-alerting-self-test` fingerprint, so it stays in a single issue.
 
 #### Checking that it works
 
@@ -257,6 +292,7 @@ systemctl start alert-systemd-sweep.service       # run it now
 journalctl -u alert-systemd-sweep.service         # what it found, and whether it could report
 systemctl list-units --failed                     # the same question, without Sentry
 curl -s https://monitor.<fullname> | jq .units    # unit states on the status page
+alert_systemd_failure.sh --self-test              # send one event and check it leaves
 ```
 
 #### Limits you need to know about
@@ -282,6 +318,16 @@ and it is not done here.
 
 **Removing a unit from `alerting_watched_units` leaves its drop-in behind.** Ansible writes
 `/etc/systemd/system/<unit>.d/50-onfailure.conf` and never removes it; delete it by hand.
+
+**The status page still queries systemd synchronously.** One `systemctl show` covers every
+unit, capped at two seconds, so a systemd that stops answering costs the page two seconds
+instead of hanging it — but requests are still served one after another while that call runs.
+Making the page fully asynchronous is a bigger change than this needed.
+
+**The source `.env` is world-readable** (`0644` in a `0755` directory), so the DSN — and
+every other application secret in it — is already readable by any local user. That predates
+this mechanism and is not fixed here; `chmod 0600` on the application `.env` would close it,
+and the alerting keeps working either way since it reads the file as root.
 
 **The status page reads unit states over the D-Bus system bus.** `monitor_service` runs as
 the deployment user, and an unprivileged `systemctl show` needs `/run/dbus/system_bus_socket`

--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ a thought for anything that handles user data.
 | `alerting_watched_units` | backup service + timer, `monitor_service`, `mongod`, `nginx`, the sweep itself | Units getting an `OnFailure=` drop-in; those with `expect_active: true` must also be running |
 | `alerting_sweep_on_calendar` | `*-*-* 08:15:00` | `OnCalendar=` of the daily sweep |
 | `alerting_sweep_max_events` | `10` | Cap on events per sweep, so a machine on fire does not open thirty issues |
-| `alerting_dsn_allowed_destinations` | `[]` | `host[:port]/project` values the DSN may point to; empty means pin-on-first-use (see below) |
+| `alerting_dsn_destination` | *(none — must be set)* | `host[:port]/project` the alerts are sent to; the key comes from the `.env` (see below) |
+| `alerting_dsn_scheme` | `https` | Only worth changing for a self-hosted Sentry over plain HTTP |
 
 Adding a unit is two lines in `alerting_watched_units`. The name must carry its systemd
 suffix — `nginx.service`, not `nginx` — or the drop-in lands in a directory systemd does not
@@ -252,27 +253,47 @@ The alerting units run as `root`, and a root unit has no business reading an app
 `.env` — that file belongs to the deployment user, and it carries every other application
 secret. The units are hardened with `ProtectHome=true` and could not read it anyway.
 
-So ansible, during `bootstrap.yaml`, extracts the single `SENTRY_CRON_DSN` line from the
-default application's `.env` and writes it to `/etc/aides-jeunes/alerting.env`, `0600
-root:root`, containing that one variable and nothing else. **No DSN is stored in this
-repository or in any inventory**, and the value never transits through an ansible variable:
-`/usr/local/sbin/sync_alerting_dsn.sh` does the extraction on the machine and only reports
-whether it changed.
+So the DSN is **composed from two sources** rather than copied from one:
 
-There is no other channel available: deployment is an SSH forced command that runs
+| Part | Comes from | Why |
+| --- | --- | --- |
+| scheme + host + port + project | `alerting_dsn_scheme` / `alerting_dsn_destination`, in the inventory | not secrets — they authenticate nothing — and reviewed like any other line of this repository |
+| public key | `SENTRY_CRON_DSN` in the application `.env`, on the machine | the only part that is a credential, so it must not be in a public repository |
+
+`/usr/local/sbin/sync_alerting_dsn.sh` reads **only the key** from the `.env`, checks it is
+made of `[A-Za-z0-9]` and nothing else, and writes
+`<scheme>://<key>@<destination>` to `/etc/aides-jeunes/alerting.env`, `0600 root:root`, one
+variable and nothing else. **No key is stored in this repository or in any inventory**, and it
+never transits through an ansible variable.
+
+That split is the whole point, and it is worth spelling out. The `.env` belongs to the
+deployment user, so everything in it is hostile by assumption. As long as the *destination*
+was read from there, the code had to decide, by comparing text, whether a third party's URL
+pointed somewhere acceptable — and comparing URLs in shell kept being defeated: first no
+anchoring at all, then the host without the path, then a glob that walked straight through
+the `/`. Composing removes the comparison entirely. A key restricted to `[A-Za-z0-9]` cannot
+contain `@`, `/` or `:`, so it cannot contribute an authority or a path, whatever the `.env`
+says.
+
+What is left to whoever controls the `.env` is putting a **wrong key**, hence *breaking* the
+alerting. They can no longer *redirect* it. That is a deliberate trade: a loud failure that
+the self-test and the daily sweep both report, instead of a silent exfiltration.
+
+The key has to come from the machine: deployment is an SSH forced command that runs
 `ansible-playbook --connection=local` on the server itself (`scripts/update_ops.sh`), with no
 way to pass `--extra-vars`, so a GitHub secret or an ansible-vault variable could not reach
 the play without a vault password file on the server — that is, the same server-side secret
-with more machinery. `bootstrap.yaml` replays on every merge to `main`, so rotating
-`SENTRY_CRON_DSN` in the `.env` propagates on the next deployment.
+with more machinery. `bootstrap.yaml` replays on every merge to `main`, so rotating the key
+in `SENTRY_CRON_DSN` propagates on the next deployment. Rotating to a different *project*
+means changing `alerting_dsn_destination` too, and the mismatch fails loudly in between.
 
-The value crosses a privilege boundary — it comes from a file the deployment user owns and
-ends up in a file that root-owned units read — so it is treated as untrusted input at every
-step:
+The key still crosses a privilege boundary — it comes from a file the deployment user owns
+and ends up in a file that root-owned units read — so it is treated as untrusted input at
+every step:
 
-- **it is validated against a character whitelist** (`A-Za-z0-9:/@._~%?=-`) before being
-  written. A `$(…)`, a backtick, a quote or a space is refused outright, with a message that
-  never prints the value;
+- **it is validated against a character whitelist** (`A-Za-z0-9`, nothing else) before being
+  used. A `$(…)`, a backtick, a quote, a space, a `/` or an `@` is refused outright, with a
+  message that never prints the value;
 - **no script ever `source`s it.** `sync_alerting_dsn.sh` reads the `.env` with `sed`, and
   `alert_systemd_failure.sh` reads `alerting.env` the same way;
 - **the units get it through `EnvironmentFile=`**, which systemd parses itself, with no shell
@@ -281,33 +302,21 @@ step:
 Any one of those would do; all three are there because a shell substitution reaching a root
 unit is not a bug you want to discover in production.
 
-Validating the syntax is not enough, because the DSN also decides **where the alerts go**, and
-they carry the journals of root units the deployment user cannot read. Whoever can write the
-`.env` could therefore both exfiltrate those journals and switch the whole supervision off by
-pointing it at a sink that answers `200` — the self-test included. So the **destination** is
-anchored too.
+#### The one manual step
 
-Destination means **host *and* path** — `o1.ingest.sentry.io/4507`, not just the host.
-Anchoring the host alone closes nothing: on a shared or self-hosted Sentry, creating a second
-project on the same host is trivial, and every alert would go there without a single
-character of the host changing. The **key** is the one field left free, because it is the one
-that has to rotate.
+`alerting_dsn_destination` has **no default** — until it is filled in, the alerting units are
+installed but inert, and the play says so with a red (ignored) task. This is deliberate. The
+value is the part of `SENTRY_CRON_DSN` after the `@`, for example
+`o4507.ingest.de.sentry.io/4507123`; read it once on the server and put it in the inventory:
 
-- if `alerting_dsn_allowed_destinations` is set, the destination must match one of its
-  patterns. Use this as soon as the real one is known;
-- if it is empty — the default — the destination is **pinned on first use**: the first run
-  adopts what the `.env` says and any later change is refused. The DSN already in place keeps
-  working meanwhile, so the refusal protects the alerting instead of cutting it.
+```yaml
+      alerting_dsn_destination: o4507.ingest.de.sentry.io/4507123
+```
 
-The default is pin-on-first-use rather than a hardcoded list because this repository cannot
-know which Sentry instance the project uses, and a wrong guess would silence production
-alerting on the very day it is deployed. That first adoption is a bet, not a check — there is
-nothing to compare against — so **it is reported as a failed (ignored) task naming the
-adopted destination**. It deserves a look: `setup_alerting` runs *before* the applications
-are provisioned, so on a brand new machine the `.env` does not exist yet and the adoption
-happens on the second bootstrap, by which time the deployment user is already running.
-Confirm the destination, then freeze it in `alerting_dsn_allowed_destinations`. Deleting
-`/etc/aides-jeunes/alerting.env` re-adopts.
+A documented manual step, done once, is the price of never again having to decide in shell
+whether a third party's URL is legitimate. It also means the destination goes through code
+review like everything else in this repository, which is exactly where such a decision
+belongs.
 
 If the `.env` is not there yet — a brand new machine — or if the DSN is malformed, the play
 prints a warning and carries on rather than blocking the application deployment, and the

--- a/README.md
+++ b/README.md
@@ -190,6 +190,111 @@ ability and data minimisation — it is the team's and the DPO's call, not a tec
 default, and `mongodb_backup_retention_days` is the knob. Whatever value is chosen should be
 reflected in the record of processing activities.
 
+### Alerting on failed systemd units
+
+A backup that fails silently for a month is the failure mode that actually hurts, and the
+status page itself sat in `failed` for a year without anyone noticing. The `bootstrap` role
+therefore makes a broken unit announce itself, through the Sentry project the cron jobs
+already report to. Nothing to run by hand — `bootstrap.yaml` installs it.
+
+Two triggers, because they catch different things:
+
+| | Fires on | Catches | Misses |
+| --- | --- | --- | --- |
+| `OnFailure=` drop-in on each watched unit | the *transition* into `failed` | a nightly backup that just died, within seconds | a unit already broken before this was deployed; a unit that is merely stopped |
+| `alert-systemd-sweep.timer`, daily at 08:15 | the *state* of the machine | everything in `systemctl --failed`, watched units that are not running, a timer that disappeared, and the alerting units' own failures | nothing until the next morning |
+
+Both run the same script, `/usr/local/sbin/alert_systemd_failure.sh`, which sends one Sentry
+event per unit with a fingerprint of `systemd-unit-failure` + the unit name — so a unit gets
+one Sentry issue, not one per day, and closing it means the panne is handled. The last 50
+journal lines of the unit ride along as breadcrumbs, so the alert says *why* without needing
+an SSH session.
+
+The sweep reads `systemctl --failed` in full, not just the list below: a failed unit nobody
+thought to declare — an `*_openfisca` service, something added later — is still reported. The
+list exists for the other half of the job, checking that a unit which should be running
+actually is, which no global query can guess.
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `alerting_watched_units` | backup service + timer, `monitor_service`, `mongod`, `nginx`, the sweep itself | Units getting an `OnFailure=` drop-in; those with `expect_active: true` must also be running |
+| `alerting_sweep_on_calendar` | `*-*-* 08:15:00` | `OnCalendar=` of the daily sweep |
+| `alerting_sweep_max_events` | `10` | Cap on events per sweep, so a machine on fire does not open thirty issues |
+
+Adding a unit is two lines in `alerting_watched_units`. The page on `monitor.<fullname>` also
+publishes the state of these units next to its URL probes.
+
+#### Where the DSN comes from
+
+The alerting units run as `root`, and a root unit has no business reading an application
+`.env` — that file belongs to the deployment user, so anyone who can write it could inject
+code into a root shell, and it carries every other application secret. The units are hardened
+with `ProtectHome=true` and could not read it anyway.
+
+So ansible, during `bootstrap.yaml`, extracts the single `SENTRY_CRON_DSN` line from the
+default application's `.env` and writes it to `/etc/aides-jeunes/alerting.env`, `0600
+root:root`, containing that one variable and nothing else. **No DSN is stored in this
+repository or in any inventory**, and the value never transits through an ansible variable:
+`/usr/local/sbin/sync_alerting_dsn.sh` does the extraction on the machine and only reports
+whether it changed.
+
+There is no other channel available: deployment is an SSH forced command that runs
+`ansible-playbook --connection=local` on the server itself (`scripts/update_ops.sh`), with no
+way to pass `--extra-vars`, so a GitHub secret or an ansible-vault variable could not reach
+the play without a vault password file on the server — that is, the same server-side secret
+with more machinery. `bootstrap.yaml` replays on every merge to `main`, so rotating
+`SENTRY_CRON_DSN` in the `.env` propagates on the next deployment.
+
+If the `.env` is not there yet — a brand new machine — the play prints a warning and carries
+on, and the alerting scripts exit non-zero with an explicit message rather than pretending to
+send anything.
+
+#### Checking that it works
+
+```bash
+systemctl list-timers alert-systemd-sweep.timer   # when the sweep last ran and runs next
+systemctl start alert-systemd-sweep.service       # run it now
+journalctl -u alert-systemd-sweep.service         # what it found, and whether it could report
+systemctl list-units --failed                     # the same question, without Sentry
+curl -s https://monitor.<fullname> | jq .units    # unit states on the status page
+```
+
+#### Limits you need to know about
+
+**A unit that restarts forever is invisible here.** A service with `Restart=on-failure` that
+crashes slowly enough never exhausts its start limit, so it never enters `failed`, never
+triggers `OnFailure=`, and never shows up in `systemctl --failed`. What catches it is the
+URL probe on the status page returning 0 or 502 — which is why the two halves of that page
+are complementary and neither replaces the other.
+
+**Sentry is a single point of failure.** If the DSN is wrong, the project is full, or the
+network is down, nothing arrives. The failure is at least loud locally: `sentry-cli` exits
+non-zero, the alerting unit lands in `failed`, and the *next* sweep reports it — verified.
+But a sweep whose timer has been disabled reports nothing at all and says nothing about it;
+the only remaining witness is then the status page, which is why the sweep units are in the
+watched list.
+
+**Nobody is paged.** These events land in Sentry like the cron failures already do, and
+inherit whatever notification rules that project has. If nobody has an alert rule on this
+project, this mechanism replaces a silence with a line in a web interface. Setting up the
+Sentry alert rule for the `systemd-unit-failure` fingerprint is the other half of the job,
+and it is not done here.
+
+**Removing a unit from `alerting_watched_units` leaves its drop-in behind.** Ansible writes
+`/etc/systemd/system/<unit>.d/50-onfailure.conf` and never removes it; delete it by hand.
+
+**The status page reads unit states over the D-Bus system bus.** `monitor_service` runs as
+the deployment user, and an unprivileged `systemctl show` needs `/run/dbus/system_bus_socket`
+— unlike the alerting units, which run as root and go through systemd's private socket. If
+`dbus` is not installed, every unit on the page comes back as `"ok": false` with the bus
+error in an `error` field, which is visible but is a false alarm. The Sentry alerting is
+unaffected.
+
+**Unit states are published on a page with no authentication**, next to the disk usage and
+the URL probes already there. It says a bit about the machine's internals — that a backup is
+broken, for instance. Only the units listed in `alerting_watched_units` are published, never
+the full `systemctl --failed` output.
+
 ### Migrating mongodb collections between servers
 
 > This is a manual, one-shot migration tool, **not** a backup. An operator triggers it, it

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ a thought for anything that handles user data.
 | `alerting_watched_units` | backup service + timer, `monitor_service`, `mongod`, `nginx`, the sweep itself | Units getting an `OnFailure=` drop-in; those with `expect_active: true` must also be running |
 | `alerting_sweep_on_calendar` | `*-*-* 08:15:00` | `OnCalendar=` of the daily sweep |
 | `alerting_sweep_max_events` | `10` | Cap on events per sweep, so a machine on fire does not open thirty issues |
-| `alerting_dsn_allowed_hosts` | `[]` | Hosts the DSN may point to; empty means pin-on-first-use (see below) |
+| `alerting_dsn_allowed_destinations` | `[]` | `host[:port]/project` values the DSN may point to; empty means pin-on-first-use (see below) |
 
 Adding a unit is two lines in `alerting_watched_units`. The name must carry its systemd
 suffix — `nginx.service`, not `nginx` — or the drop-in lands in a directory systemd does not
@@ -237,13 +237,14 @@ names the offending entries. The page on `monitor.<fullname>` also publishes the
 these units next to its URL probes.
 
 **Nothing in this chain is allowed to wait forever.** `sentry-cli` has no timeout option of
-its own, so every call is wrapped in `timeout 30`, and both units carry a `TimeoutStartSec=`.
-Without them, a connection that is accepted and never answered — a stateful firewall, a NAT,
-a saturated ingest — leaves the sweep `activating` indefinitely; systemd then merges the next
-day's trigger into the job already running, and **the alerting stops for good without
-anything ever turning `failed`**. The status page treats a long `activating` as not-ok for
-the same reason: the witness of last resort must not certify that all is well while the chain
-is dead.
+its own, so every call is wrapped in `timeout -k 5 30`, and both units carry a
+`TimeoutStartSec=` — derived from `alerting_sweep_max_events` for the sweep, so raising the
+cap does not silently truncate it. Without those, a connection that is accepted and never
+answered — a stateful firewall, a NAT, a saturated ingest — leaves the sweep `activating`
+indefinitely; systemd then merges the next day's trigger into the job already running, and
+**the alerting stops for good without anything ever turning `failed`**. The status page
+treats `activating` as not-ok for the same reason: the witness of last resort must not
+certify that all is well while the chain is dead.
 
 #### Where the DSN comes from
 
@@ -283,21 +284,30 @@ unit is not a bug you want to discover in production.
 Validating the syntax is not enough, because the DSN also decides **where the alerts go**, and
 they carry the journals of root units the deployment user cannot read. Whoever can write the
 `.env` could therefore both exfiltrate those journals and switch the whole supervision off by
-pointing it at a sink that answers `200` — the self-test included. So the **host** is anchored
-too:
+pointing it at a sink that answers `200` — the self-test included. So the **destination** is
+anchored too.
 
-- if `alerting_dsn_allowed_hosts` is set, the host must match one of its patterns
-  (`*.ingest.sentry.io` and the like). Use this as soon as the real host is known;
-- if it is empty — the default — the host is **pinned on first use**: the first run adopts
-  whatever the `.env` says, and any later change of host is refused. The DSN already in place
-  keeps working meanwhile, so the refusal protects the alerting instead of cutting it.
+Destination means **host *and* path** — `o1.ingest.sentry.io/4507`, not just the host.
+Anchoring the host alone closes nothing: on a shared or self-hosted Sentry, creating a second
+project on the same host is trivial, and every alert would go there without a single
+character of the host changing. The **key** is the one field left free, because it is the one
+that has to rotate.
+
+- if `alerting_dsn_allowed_destinations` is set, the destination must match one of its
+  patterns. Use this as soon as the real one is known;
+- if it is empty — the default — the destination is **pinned on first use**: the first run
+  adopts what the `.env` says and any later change is refused. The DSN already in place keeps
+  working meanwhile, so the refusal protects the alerting instead of cutting it.
 
 The default is pin-on-first-use rather than a hardcoded list because this repository cannot
 know which Sentry instance the project uses, and a wrong guess would silence production
-alerting on the very day it is deployed. Changing host legitimately means setting
-`alerting_dsn_allowed_hosts`, or deleting `/etc/aides-jeunes/alerting.env` to re-adopt. Only
-the host is pinned: rotating the key, or changing the port or project id, goes through
-untouched.
+alerting on the very day it is deployed. That first adoption is a bet, not a check — there is
+nothing to compare against — so **it is reported as a failed (ignored) task naming the
+adopted destination**. It deserves a look: `setup_alerting` runs *before* the applications
+are provisioned, so on a brand new machine the `.env` does not exist yet and the adoption
+happens on the second bootstrap, by which time the deployment user is already running.
+Confirm the destination, then freeze it in `alerting_dsn_allowed_destinations`. Deleting
+`/etc/aides-jeunes/alerting.env` re-adopts.
 
 If the `.env` is not there yet — a brand new machine — or if the DSN is malformed, the play
 prints a warning and carries on rather than blocking the application deployment, and the
@@ -358,6 +368,14 @@ and it is not done here.
 
 **Removing a unit from `alerting_watched_units` leaves its drop-in behind.** Ansible writes
 `/etc/systemd/system/<unit>.d/50-onfailure.conf` and never removes it; delete it by hand.
+
+**The status page goes red every night during the backup.** `activating` is never counted as
+healthy, and `mongodb-backup.service` is `activating` for as long as `mongodump` runs. So
+from 03:30 onwards, for the duration of the dump, the public page shows that unit as
+`"ok": false`. That is the deliberate price of not letting a stuck `oneshot` look green — and
+note that the danger this rule guards against, the endless wait, is also addressed by
+`TimeoutStartSec=`; the rule is the second line of defence, not the only one. `reloading` is
+counted as healthy, so a `systemctl reload nginx` does not trip it.
 
 **The status page still queries systemd synchronously.** One `systemctl show` covers every
 unit, capped at two seconds, so a systemd that stops answering costs the page two seconds

--- a/roles/bootstrap/defaults/main.yaml
+++ b/roles/bootstrap/defaults/main.yaml
@@ -105,14 +105,19 @@ alerting_sweep_on_calendar: "*-*-* 08:15:00"
 # échec n'a pas besoin de trente tickets : les premières suffisent à alerter,
 # et le décompte complet part dans le journal.
 alerting_sweep_max_events: 10
-# Hôtes vers lesquels le DSN a le droit de pointer, motifs glob acceptés
-# (« *.ingest.sentry.io »). Le DSN vient d'un fichier que possède l'utilisateur
-# de déploiement : il décide donc où partent les journaux d'unités root que les
-# alertes emportent, et permettrait d'éteindre toute la supervision en la
-# redirigeant vers un puits qui répond 200.
-# Liste vide = épinglage sur premier usage : le premier passage adopte l'hôte
-# trouvé dans le .env, tout changement ultérieur est refusé, et le DSN déjà en
-# place continue de servir. C'est le défaut parce qu'il ne suppose rien de
-# l'hôte réel — il ne peut donc pas couper l'alerte en production le jour du
-# déploiement. Renseigner la liste dès que l'hôte est connu : c'est plus sûr.
-alerting_dsn_allowed_hosts: []
+# Destinations vers lesquelles le DSN a le droit de pointer, motifs glob
+# acceptés. Une destination est « hôte[:port]/projet », par exemple
+# « o1.ingest.sentry.io/4507 ». L'hôte SEUL ne suffirait pas : créer un second
+# projet sur le même Sentry — mutualisé ou auto-hébergé — rouvrirait tout le
+# détournement sans changer un caractère de l'hôte. La clé, elle, reste libre :
+# c'est le seul champ qui doit pouvoir tourner.
+# Le DSN vient d'un fichier que possède l'utilisateur de déploiement : il décide
+# donc où partent les journaux d'unités root que les alertes emportent, et
+# pourrait éteindre toute la supervision derrière un puits qui répond 200.
+# Liste vide = épinglage sur premier usage : la première destination vue est
+# adoptée — et l'adoption sort en rouge au déploiement, parce que personne ne
+# l'a vérifiée — puis tout changement est refusé. C'est le défaut parce qu'il ne
+# suppose rien de l'instance Sentry réelle, donc qu'il ne peut pas couper
+# l'alerte en production le jour du déploiement.
+# Renseigner la liste dès que la destination est connue : c'est plus sûr.
+alerting_dsn_allowed_destinations: []

--- a/roles/bootstrap/defaults/main.yaml
+++ b/roles/bootstrap/defaults/main.yaml
@@ -71,6 +71,9 @@ alerting_sweep_service_name: alert-systemd-sweep
 # publie leur état.
 # `expect_active: false` pour un service déclenché par un timer : son état
 # normal est « inactive », seul l'échec compte.
+# Le nom doit porter son suffixe systemd. « nginx » tout court poserait le
+# greffon dans /etc/systemd/system/nginx.d, que systemd ne lit pas, et l'unité
+# compterait pour deux au balayage. Une vérification l'impose au déploiement.
 # Ajouter une unité = deux lignes ici, rien d'autre. Une unité en échec que
 # personne n'a pensé à lister est de toute façon remontée par le balayage, qui
 # lit `systemctl --failed` en entier — la liste sert à ce que la simple absence
@@ -102,3 +105,14 @@ alerting_sweep_on_calendar: "*-*-* 08:15:00"
 # échec n'a pas besoin de trente tickets : les premières suffisent à alerter,
 # et le décompte complet part dans le journal.
 alerting_sweep_max_events: 10
+# Hôtes vers lesquels le DSN a le droit de pointer, motifs glob acceptés
+# (« *.ingest.sentry.io »). Le DSN vient d'un fichier que possède l'utilisateur
+# de déploiement : il décide donc où partent les journaux d'unités root que les
+# alertes emportent, et permettrait d'éteindre toute la supervision en la
+# redirigeant vers un puits qui répond 200.
+# Liste vide = épinglage sur premier usage : le premier passage adopte l'hôte
+# trouvé dans le .env, tout changement ultérieur est refusé, et le DSN déjà en
+# place continue de servir. C'est le défaut parce qu'il ne suppose rien de
+# l'hôte réel — il ne peut donc pas couper l'alerte en production le jour du
+# déploiement. Renseigner la liste dès que l'hôte est connu : c'est plus sûr.
+alerting_dsn_allowed_hosts: []

--- a/roles/bootstrap/defaults/main.yaml
+++ b/roles/bootstrap/defaults/main.yaml
@@ -61,3 +61,44 @@ mongodb_backup_min_document_ratio_percent: 90
 # variations légitimes — une campagne d'anonymisation, une purge — et une alerte
 # qui crie pour rien finit ignorée.
 mongodb_backup_min_size_ratio_percent: 50
+
+# Alerte sur unité systemd en échec
+alerting_failure_service_name: alert-systemd-failure
+alerting_sweep_service_name: alert-systemd-sweep
+# Unités surveillées. Chacune reçoit un `OnFailure=` qui pousse un événement
+# Sentry dès qu'elle tombe en échec ; le balayage quotidien vérifie en plus que
+# celles marquées `expect_active` tournent bien, et la page de supervision
+# publie leur état.
+# `expect_active: false` pour un service déclenché par un timer : son état
+# normal est « inactive », seul l'échec compte.
+# Ajouter une unité = deux lignes ici, rien d'autre. Une unité en échec que
+# personne n'a pensé à lister est de toute façon remontée par le balayage, qui
+# lit `systemctl --failed` en entier — la liste sert à ce que la simple absence
+# d'une unité, elle, se voie aussi.
+alerting_watched_units:
+  - name: monitor_service.service
+    expect_active: true
+  - name: mongodb-backup.service
+    expect_active: false
+  - name: mongodb-backup.timer
+    expect_active: true
+  - name: mongod.service
+    expect_active: true
+  - name: nginx.service
+    expect_active: true
+  # Le mécanisme d'alerte se surveille lui-même : c'est la seule chose que le
+  # balayage ne peut pas rattraper tout seul s'il ne tourne plus, et la page de
+  # supervision devient alors le dernier témoin.
+  - name: "{{ alerting_sweep_service_name }}.service"
+    expect_active: false
+  - name: "{{ alerting_sweep_service_name }}.timer"
+    expect_active: true
+# 08h15 : le balayage est le filet, pas le canal rapide — `OnFailure=` a déjà
+# signalé la panne à la seconde où elle est survenue. L'heure est choisie dans
+# la journée de travail pour que la relance quotidienne d'une panne persistante
+# tombe quand quelqu'un est là, et après la sauvegarde de 03h30.
+alerting_sweep_on_calendar: "*-*-* 08:15:00"
+# Plafond d'événements par balayage. Une machine dont trente unités sont en
+# échec n'a pas besoin de trente tickets : les premières suffisent à alerter,
+# et le décompte complet part dans le journal.
+alerting_sweep_max_events: 10

--- a/roles/bootstrap/defaults/main.yaml
+++ b/roles/bootstrap/defaults/main.yaml
@@ -105,19 +105,26 @@ alerting_sweep_on_calendar: "*-*-* 08:15:00"
 # échec n'a pas besoin de trente tickets : les premières suffisent à alerter,
 # et le décompte complet part dans le journal.
 alerting_sweep_max_events: 10
-# Destinations vers lesquelles le DSN a le droit de pointer, motifs glob
-# acceptés. Une destination est « hôte[:port]/projet », par exemple
-# « o1.ingest.sentry.io/4507 ». L'hôte SEUL ne suffirait pas : créer un second
-# projet sur le même Sentry — mutualisé ou auto-hébergé — rouvrirait tout le
-# détournement sans changer un caractère de l'hôte. La clé, elle, reste libre :
-# c'est le seul champ qui doit pouvoir tourner.
-# Le DSN vient d'un fichier que possède l'utilisateur de déploiement : il décide
-# donc où partent les journaux d'unités root que les alertes emportent, et
-# pourrait éteindre toute la supervision derrière un puits qui répond 200.
-# Liste vide = épinglage sur premier usage : la première destination vue est
-# adoptée — et l'adoption sort en rouge au déploiement, parce que personne ne
-# l'a vérifiée — puis tout changement est refusé. C'est le défaut parce qu'il ne
-# suppose rien de l'instance Sentry réelle, donc qu'il ne peut pas couper
-# l'alerte en production le jour du déploiement.
-# Renseigner la liste dès que la destination est connue : c'est plus sûr.
-alerting_dsn_allowed_destinations: []
+# Destination du DSN d'alerte : « hôte[:port]/projet », sans schéma ni clé.
+# Par exemple « o4507.ingest.de.sentry.io/4507123 ».
+#
+# À RENSEIGNER DANS L'INVENTAIRE. Tant qu'elle est vide, les unités d'alerte
+# sont installées mais inertes, et le déploiement le dit en rouge. C'est le seul
+# geste manuel de ce mécanisme, et il est délibéré.
+#
+# Pourquoi ici, alors que le DSN complet existe déjà dans le .env applicatif :
+# ce .env appartient à l'utilisateur de déploiement. Y lire la destination
+# revient à laisser un tiers choisir où partent les journaux d'unités root que
+# les alertes emportent, donc à décider par comparaison de texte si l'URL qu'il
+# propose est légitime. Cette comparaison s'est fait contourner trois fois de
+# suite, chaque fois par une variante plus fine — pas d'ancrage, puis l'hôte
+# sans le chemin, puis un glob qui traverse la barre oblique. Ici il n'y a plus
+# de comparaison du tout : la destination est une constante du dépôt, relue en
+# revue de code, et seule la clé publique vient du .env, restreinte à
+# [A-Za-z0-9] — donc incapable de porter une autorité ou un chemin.
+#
+# Ni l'hôte ni le numéro de projet ne sont des secrets : ils n'authentifient
+# rien, seule la clé le fait. Leur place est donc bien dans le dépôt.
+alerting_dsn_destination: ""
+# https, sauf Sentry auto-hébergé en clair sur un réseau de confiance.
+alerting_dsn_scheme: https

--- a/roles/bootstrap/tasks/main.yaml
+++ b/roles/bootstrap/tasks/main.yaml
@@ -44,6 +44,10 @@
   ansible.builtin.include_tasks: setup_monitor.yaml
   when: monitor and monitor.port
 
+## Setup systemd failure alerting
+- name: Configure systemd failure alerting
+  ansible.builtin.include_tasks: setup_alerting.yaml
+
 ## Provision and setup all applications
 - name: Setup default application site
   ansible.builtin.include_tasks: nginx_application_default_site.yaml

--- a/roles/bootstrap/tasks/setup_alerting.yaml
+++ b/roles/bootstrap/tasks/setup_alerting.yaml
@@ -5,9 +5,11 @@
     alerting_env_file: /etc/aides-jeunes/alerting.env
     alerting_script_path: /usr/local/sbin/alert_systemd_failure.sh
     alerting_dsn_sync_script_path: /usr/local/sbin/sync_alerting_dsn.sh
-    # Le DSN d'alerte est déjà sur la machine, dans le .env de l'application par
-    # défaut : c'est celui qu'utilisent les tâches cron. On le reprend là plutôt
-    # que d'en introduire un second à gérer et à faire tourner.
+    # La CLÉ du DSN d'alerte est déjà sur la machine, dans le .env de
+    # l'application par défaut : c'est celle qu'utilisent les tâches cron. On la
+    # reprend là plutôt que d'en introduire une seconde à gérer et à faire
+    # tourner. La destination, elle, vient de l'inventaire — voir
+    # `alerting_dsn_destination` dans defaults/main.yaml.
     alerting_dsn_applications: >-
       {{ applications | selectattr('default_site', 'defined')
          | selectattr('default_site') | map(attribute='name') | list }}
@@ -33,6 +35,52 @@
       SENTRY_CRON_DSN. Les unités d'alerte sont installées mais resteront muettes.
     quiet: true
   register: alerting_default_application_check
+  ignore_errors: true
+# Le seul geste manuel de ce mécanisme. Il est assumé : lire la destination dans
+# le .env applicatif reviendrait à laisser l'utilisateur de déploiement choisir
+# où partent les journaux d'unités root, et à trancher par comparaison d'URL —
+# ce qui s'est fait contourner trois fois de suite.
+- name: Check that an alerting DSN destination is declared
+  ansible.builtin.assert:
+    that: alerting_dsn_destination | length > 0
+    fail_msg: >-
+      `alerting_dsn_destination` est vide : l'alerte est installée mais inerte.
+      Renseigner « hôte[:port]/projet » dans l'inventaire — la valeur se lit dans
+      SENTRY_CRON_DSN sur le serveur, entre le « @ » et la fin. Ni l'hôte ni le
+      numéro de projet ne sont des secrets, seule la clé en est un et elle reste
+      dans le .env.
+    quiet: true
+  register: alerting_dsn_destination_check
+  ignore_errors: true
+# La destination vient du dépôt, donc une faute de frappe y est une erreur de
+# revue, pas une attaque. Ce contrôle sert à la rendre lisible tout de suite
+# plutôt qu'à travers un échec de sentry-cli trois tâches plus loin.
+- name: Check that the alerting DSN destination is well formed
+  when: alerting_dsn_destination | length > 0
+  ansible.builtin.assert:
+    that:
+      - alerting_dsn_destination is match('^[A-Za-z0-9._~-]+(:[0-9]+)?/[A-Za-z0-9]+$')
+      - alerting_dsn_scheme in ['http', 'https']
+    fail_msg: >-
+      `alerting_dsn_destination` doit s'écrire « hôte[:port]/projet »
+      (exemple : o4507.ingest.de.sentry.io/4507123), sans schéma ni clé, et
+      `alerting_dsn_scheme` vaut http ou https. Reçu :
+      {{ alerting_dsn_scheme }}://{{ alerting_dsn_destination }}
+    quiet: true
+  register: alerting_dsn_destination_format_check
+  ignore_errors: true
+- name: Check that the sweep event cap is a sane integer
+  ansible.builtin.assert:
+    that:
+      - alerting_sweep_max_events is integer
+      - alerting_sweep_max_events | int >= 1
+      - alerting_sweep_max_events | int <= 500
+    fail_msg: >-
+      `alerting_sweep_max_events` doit être un entier entre 1 et 500. Reçu :
+      {{ alerting_sweep_max_events }}. Hors de ces bornes, le délai de garde
+      calculé du balayage devient nul ou négatif, que systemd lit « infinity ».
+    quiet: true
+  register: alerting_sweep_cap_check
   ignore_errors: true
 # Sans suffixe systemd, le greffon atterrit dans un répertoire que systemd ne lit
 # pas — /etc/systemd/system/nginx.d au lieu de nginx.service.d — et la même unité
@@ -60,8 +108,14 @@
     owner: root
     group: root
     mode: "0700"
+- name: Set whether the alerting DSN can be composed
+  ansible.builtin.set_fact:
+    alerting_dsn_ready: >-
+      {{ (alerting_dsn_source | length > 0)
+         and (alerting_dsn_destination | length > 0)
+         and (alerting_dsn_destination_format_check.failed | default(true) is false) }}
 - name: Install alerting DSN synchronisation script
-  when: alerting_dsn_source | length > 0
+  when: alerting_dsn_ready
   ansible.builtin.template:
     src: templates/alerting/sync_alerting_dsn.sh.j2
     dest: "{{ alerting_dsn_sync_script_path }}"
@@ -72,42 +126,23 @@
 # sur le serveur. Sur une machine neuve il n'existe pas encore.
 # `timeout` en tête de commande : le module `command` n'a pas de délai de garde,
 # et un .env remplacé par un tube nommé bloquerait le déploiement sans fin.
-- name: Copy the Sentry DSN into the alerting environment file
-  when: alerting_dsn_source | length > 0
+- name: Compose the alerting DSN from the declared destination and the .env key
+  when: alerting_dsn_ready
   ansible.builtin.command:
     cmd: timeout 60 {{ alerting_dsn_sync_script_path }}
   register: alerting_dsn_sync
-  changed_when: >-
-    'DSN mis à jour.' in alerting_dsn_sync.stdout
-    or 'DSN adopté' in alerting_dsn_sync.stdout
+  changed_when: "'DSN mis à jour.' in alerting_dsn_sync.stdout"
   failed_when: false
-# Adopter une destination sans rien à quoi la comparer n'est pas une
-# vérification, c'est un pari. Il est tenu parce que l'alternative — refuser —
-# laisserait la supervision éteinte sur toute machine où personne n'a renseigné
-# la liste. Mais il doit se voir : `setup_alerting` tourne avant le
-# provisionnement des applications, donc l'adoption a lieu au deuxième bootstrap,
-# quand l'utilisateur de déploiement tourne déjà et peut avoir écrit le .env.
-- name: Check that no Sentry destination was adopted unverified
-  when: alerting_dsn_source | length > 0
-  ansible.builtin.assert:
-    that: "'DSN adopté' not in alerting_dsn_sync.stdout"
-    fail_msg: >-
-      {{ alerting_dsn_sync.stdout | default('') | trim }}
-      Aucune destination n'était épinglée et `alerting_dsn_allowed_destinations` est vide :
-      celle du .env vient d'être adoptée sans avoir été vérifiée. Confirmer qu'elle est
-      légitime, puis la figer dans `alerting_dsn_allowed_destinations`.
-    quiet: true
-  register: alerting_dsn_adoption_check
-  ignore_errors: true
-- name: Check that the Sentry DSN could be copied
-  when: alerting_dsn_source | length > 0
+- name: Check that the alerting DSN could be composed
+  when: alerting_dsn_ready
   ansible.builtin.assert:
     that: alerting_dsn_sync.rc == 0
     fail_msg: >-
-      SENTRY_CRON_DSN n'a pas pu être recopié dans {{ alerting_env_file }} :
+      Le DSN d'alerte n'a pas pu être écrit dans {{ alerting_env_file }} :
       {{ alerting_dsn_sync.stderr | default('') }}
       Les unités d'alerte échoueront bruyamment tant que ce sera le cas.
-      Corriger {{ alerting_dsn_source }} puis rejouer bootstrap.yaml.
+      Corriger la clé SENTRY_CRON_DSN dans {{ alerting_dsn_source }} puis rejouer
+      bootstrap.yaml.
     quiet: true
   register: alerting_dsn_sync_check
   ignore_errors: true

--- a/roles/bootstrap/tasks/setup_alerting.yaml
+++ b/roles/bootstrap/tasks/setup_alerting.yaml
@@ -1,0 +1,111 @@
+---
+- name: Set alerting variables
+  ansible.builtin.set_fact:
+    alerting_directory: /etc/aides-jeunes
+    alerting_env_file: /etc/aides-jeunes/alerting.env
+    alerting_script_path: /usr/local/sbin/alert_systemd_failure.sh
+    alerting_dsn_sync_script_path: /usr/local/sbin/sync_alerting_dsn.sh
+    # Le DSN d'alerte est déjà sur la machine, dans le .env de l'application par
+    # défaut : c'est celui qu'utilisent les tâches cron. On le reprend là plutôt
+    # que d'en introduire un second à gérer et à faire tourner.
+    alerting_dsn_source: >-
+      /home/{{ server_user_name }}/{{ applications | selectattr('default_site', 'defined')
+      | selectattr('default_site') | map(attribute='name') | first }}/repository/.env
+- name: Create alerting configuration directory
+  ansible.builtin.file:
+    path: "{{ alerting_directory }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0700"
+- name: Install alerting DSN synchronisation script
+  ansible.builtin.template:
+    src: templates/alerting/sync_alerting_dsn.sh.j2
+    dest: "{{ alerting_dsn_sync_script_path }}"
+    owner: root
+    group: root
+    mode: "0700"
+# Le .env applicatif n'est pas produit par ce dépôt : il est déposé à la main
+# sur le serveur. Sur une machine neuve il n'existe pas encore, et l'alerte doit
+# le dire au lieu de faire échouer tout le bootstrap.
+- name: Check that the application environment file exists
+  ansible.builtin.stat:
+    path: "{{ alerting_dsn_source }}"
+  register: alerting_dsn_source_stat
+- name: Copy the Sentry DSN into the alerting environment file
+  when: alerting_dsn_source_stat.stat.exists
+  ansible.builtin.command:
+    cmd: "{{ alerting_dsn_sync_script_path }}"
+  register: alerting_dsn_sync
+  changed_when: "'DSN mis à jour.' in alerting_dsn_sync.stdout"
+- name: Report a missing DSN source
+  when: not alerting_dsn_source_stat.stat.exists
+  ansible.builtin.debug:
+    msg: >-
+      [WARNING] {{ alerting_dsn_source }} est absent : SENTRY_CRON_DSN n'a pas pu être
+      recopié dans {{ alerting_env_file }}. Les unités d'alerte échoueront bruyamment
+      tant que ce fichier n'existe pas. Le déposer puis rejouer bootstrap.yaml.
+- name: Install systemd failure alerting script
+  ansible.builtin.template:
+    src: templates/alerting/alert_systemd_failure.sh.j2
+    dest: "{{ alerting_script_path }}"
+    owner: root
+    group: root
+    mode: "0700"
+- name: Setup systemd failure alerting service template
+  ansible.builtin.template:
+    src: templates/alerting/alert-systemd-failure@.service.j2
+    dest: /etc/systemd/system/{{ alerting_failure_service_name }}@.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+- name: Setup systemd sweep service
+  ansible.builtin.template:
+    src: templates/alerting/alert-systemd-sweep.service.j2
+    dest: /etc/systemd/system/{{ alerting_sweep_service_name }}.service
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+- name: Setup systemd sweep timer
+  ansible.builtin.template:
+    src: templates/alerting/alert-systemd-sweep.timer.j2
+    dest: /etc/systemd/system/{{ alerting_sweep_service_name }}.timer
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Reload systemd
+- name: Create drop-in directory for each watched unit
+  ansible.builtin.file:
+    path: /etc/systemd/system/{{ watched_unit.name }}.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  loop: "{{ alerting_watched_units }}"
+  loop_control:
+    loop_var: watched_unit
+    label: "{{ watched_unit.name }}"
+- name: Wire OnFailure alerting on each watched unit
+  ansible.builtin.template:
+    src: templates/alerting/onfailure.conf.j2
+    dest: /etc/systemd/system/{{ watched_unit.name }}.d/50-onfailure.conf
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ alerting_watched_units }}"
+  loop_control:
+    loop_var: watched_unit
+    label: "{{ watched_unit.name }}"
+  notify: Reload systemd
+# Le gestionnaire de rechargement est différé jusqu'au prochain point de
+# synchronisation : sans ce drapeau, systemd démarrerait le timer sur une
+# définition d'unité qu'il ne connaît pas encore.
+- name: Reload systemd before enabling the sweep timer
+  ansible.builtin.meta: flush_handlers
+- name: Enable and start the systemd sweep timer
+  ansible.builtin.systemd:
+    name: "{{ alerting_sweep_service_name }}.timer"
+    enabled: true
+    state: started

--- a/roles/bootstrap/tasks/setup_alerting.yaml
+++ b/roles/bootstrap/tasks/setup_alerting.yaml
@@ -77,8 +77,28 @@
   ansible.builtin.command:
     cmd: timeout 60 {{ alerting_dsn_sync_script_path }}
   register: alerting_dsn_sync
-  changed_when: "'DSN mis à jour.' in alerting_dsn_sync.stdout"
+  changed_when: >-
+    'DSN mis à jour.' in alerting_dsn_sync.stdout
+    or 'DSN adopté' in alerting_dsn_sync.stdout
   failed_when: false
+# Adopter une destination sans rien à quoi la comparer n'est pas une
+# vérification, c'est un pari. Il est tenu parce que l'alternative — refuser —
+# laisserait la supervision éteinte sur toute machine où personne n'a renseigné
+# la liste. Mais il doit se voir : `setup_alerting` tourne avant le
+# provisionnement des applications, donc l'adoption a lieu au deuxième bootstrap,
+# quand l'utilisateur de déploiement tourne déjà et peut avoir écrit le .env.
+- name: Check that no Sentry destination was adopted unverified
+  when: alerting_dsn_source | length > 0
+  ansible.builtin.assert:
+    that: "'DSN adopté' not in alerting_dsn_sync.stdout"
+    fail_msg: >-
+      {{ alerting_dsn_sync.stdout | default('') | trim }}
+      Aucune destination n'était épinglée et `alerting_dsn_allowed_destinations` est vide :
+      celle du .env vient d'être adoptée sans avoir été vérifiée. Confirmer qu'elle est
+      légitime, puis la figer dans `alerting_dsn_allowed_destinations`.
+    quiet: true
+  register: alerting_dsn_adoption_check
+  ignore_errors: true
 - name: Check that the Sentry DSN could be copied
   when: alerting_dsn_source | length > 0
   ansible.builtin.assert:

--- a/roles/bootstrap/tasks/setup_alerting.yaml
+++ b/roles/bootstrap/tasks/setup_alerting.yaml
@@ -19,13 +19,40 @@
     alerting_dsn_source: >-
       {{ ('/home/' ~ server_user_name ~ '/' ~ alerting_dsn_applications[0] ~ '/repository/.env')
          if (alerting_dsn_applications | length == 1) else '' }}
-- name: Report an inventory without exactly one default application
-  when: alerting_dsn_applications | length != 1
-  ansible.builtin.debug:
-    msg: >-
-      [WARNING] L'inventaire déclare {{ alerting_dsn_applications | length }} application(s)
+# Les contrôles de ce fichier sont des `assert` ignorés, et non des `debug` :
+# une chaîne d'alerte morte ne doit pas interrompre le déploiement de
+# l'application — le mécanisme censé signaler les pannes en deviendrait une —
+# mais un message noyé dans des centaines de lignes vertes n'est pas un signal.
+# Ignorés, ils sortent en rouge et font apparaître `ignored=` au récapitulatif.
+- name: Check that exactly one default application is declared
+  ansible.builtin.assert:
+    that: alerting_dsn_applications | length == 1
+    fail_msg: >-
+      L'inventaire déclare {{ alerting_dsn_applications | length }} application(s)
       avec `default_site: true` ; il en faut exactement une pour savoir où lire
       SENTRY_CRON_DSN. Les unités d'alerte sont installées mais resteront muettes.
+    quiet: true
+  register: alerting_default_application_check
+  ignore_errors: true
+# Sans suffixe systemd, le greffon atterrit dans un répertoire que systemd ne lit
+# pas — /etc/systemd/system/nginx.d au lieu de nginx.service.d — et la même unité
+# compte pour deux au balayage, sous deux empreintes différentes. La promesse
+# « ajouter une unité = deux lignes » suppose que ce contrôle existe.
+- name: Check that every watched unit name carries its systemd suffix
+  ansible.builtin.assert:
+    that: >-
+      alerting_watched_units | rejectattr('name', 'search',
+        '\.(service|timer|socket|mount|path|target|slice|scope|swap|automount|device)$')
+      | list | length == 0
+    fail_msg: >-
+      Ces unités de `alerting_watched_units` n'ont pas de suffixe systemd :
+      {{ alerting_watched_units | rejectattr('name', 'search',
+         '\.(service|timer|socket|mount|path|target|slice|scope|swap|automount|device)$')
+         | map(attribute='name') | join(', ') }}.
+      Leur greffon OnFailure= ne sera pas lu par systemd.
+    quiet: true
+  register: alerting_unit_names_check
+  ignore_errors: true
 - name: Create alerting configuration directory
   ansible.builtin.file:
     path: "{{ alerting_directory }}"
@@ -43,27 +70,27 @@
     mode: "0700"
 # Le .env applicatif n'est pas produit par ce dépôt : il est déposé à la main
 # sur le serveur. Sur une machine neuve il n'existe pas encore.
-# `failed_when: false` : une configuration d'alerte incomplète ne doit pas
-# interrompre le déploiement de l'application — le mécanisme censé signaler les
-# pannes serait alors lui-même une panne. L'échec n'est pas avalé pour autant :
-# il est rapporté juste en dessous, et l'auto-contrôle de fin de rôle le redit.
+# `timeout` en tête de commande : le module `command` n'a pas de délai de garde,
+# et un .env remplacé par un tube nommé bloquerait le déploiement sans fin.
 - name: Copy the Sentry DSN into the alerting environment file
   when: alerting_dsn_source | length > 0
   ansible.builtin.command:
-    cmd: "{{ alerting_dsn_sync_script_path }}"
+    cmd: timeout 60 {{ alerting_dsn_sync_script_path }}
   register: alerting_dsn_sync
   changed_when: "'DSN mis à jour.' in alerting_dsn_sync.stdout"
   failed_when: false
-- name: Report a DSN that could not be copied
-  when:
-    - alerting_dsn_source | length > 0
-    - alerting_dsn_sync.rc != 0
-  ansible.builtin.debug:
-    msg: >-
-      [WARNING] SENTRY_CRON_DSN n'a pas pu être recopié dans {{ alerting_env_file }} :
+- name: Check that the Sentry DSN could be copied
+  when: alerting_dsn_source | length > 0
+  ansible.builtin.assert:
+    that: alerting_dsn_sync.rc == 0
+    fail_msg: >-
+      SENTRY_CRON_DSN n'a pas pu être recopié dans {{ alerting_env_file }} :
       {{ alerting_dsn_sync.stderr | default('') }}
       Les unités d'alerte échoueront bruyamment tant que ce sera le cas.
       Corriger {{ alerting_dsn_source }} puis rejouer bootstrap.yaml.
+    quiet: true
+  register: alerting_dsn_sync_check
+  ignore_errors: true
 - name: Install systemd failure alerting script
   ansible.builtin.template:
     src: templates/alerting/alert_systemd_failure.sh.j2
@@ -151,14 +178,17 @@
     or alerting_failure_unit is changed
     or alerting_sweep_unit is changed
   ansible.builtin.command:
-    cmd: "{{ alerting_script_path }} --self-test"
+    cmd: timeout 60 {{ alerting_script_path }} --self-test
   register: alerting_self_test
   changed_when: false
   failed_when: false
-- name: Report an alerting chain that cannot reach Sentry
-  when: alerting_self_test.rc | default(0) != 0
-  ansible.builtin.debug:
-    msg: >-
-      [WARNING] L'auto-contrôle a échoué : aucun événement n'a pu être émis vers Sentry.
+- name: Check that the alerting chain reaches Sentry
+  ansible.builtin.assert:
+    that: alerting_self_test.rc | default(0) == 0
+    fail_msg: >-
+      L'auto-contrôle a échoué : aucun événement n'a pu être émis vers Sentry.
       {{ alerting_self_test.stderr | default('') }}
       Les unités systemd en échec ne seront signalées à personne tant que ce sera le cas.
+    quiet: true
+  register: alerting_self_test_check
+  ignore_errors: true

--- a/roles/bootstrap/tasks/setup_alerting.yaml
+++ b/roles/bootstrap/tasks/setup_alerting.yaml
@@ -8,9 +8,24 @@
     # Le DSN d'alerte est déjà sur la machine, dans le .env de l'application par
     # défaut : c'est celui qu'utilisent les tâches cron. On le reprend là plutôt
     # que d'en introduire un second à gérer et à faire tourner.
+    alerting_dsn_applications: >-
+      {{ applications | selectattr('default_site', 'defined')
+         | selectattr('default_site') | map(attribute='name') | list }}
+# Chaîne vide plutôt que `| first` sur une séquence potentiellement vide, qui
+# rendrait « No first item, sequence was empty » à mi-parcours du bootstrap sans
+# dire de quoi il s'agit.
+- name: Set the alerting DSN source
+  ansible.builtin.set_fact:
     alerting_dsn_source: >-
-      /home/{{ server_user_name }}/{{ applications | selectattr('default_site', 'defined')
-      | selectattr('default_site') | map(attribute='name') | first }}/repository/.env
+      {{ ('/home/' ~ server_user_name ~ '/' ~ alerting_dsn_applications[0] ~ '/repository/.env')
+         if (alerting_dsn_applications | length == 1) else '' }}
+- name: Report an inventory without exactly one default application
+  when: alerting_dsn_applications | length != 1
+  ansible.builtin.debug:
+    msg: >-
+      [WARNING] L'inventaire déclare {{ alerting_dsn_applications | length }} application(s)
+      avec `default_site: true` ; il en faut exactement une pour savoir où lire
+      SENTRY_CRON_DSN. Les unités d'alerte sont installées mais resteront muettes.
 - name: Create alerting configuration directory
   ansible.builtin.file:
     path: "{{ alerting_directory }}"
@@ -19,6 +34,7 @@
     group: root
     mode: "0700"
 - name: Install alerting DSN synchronisation script
+  when: alerting_dsn_source | length > 0
   ansible.builtin.template:
     src: templates/alerting/sync_alerting_dsn.sh.j2
     dest: "{{ alerting_dsn_sync_script_path }}"
@@ -26,25 +42,28 @@
     group: root
     mode: "0700"
 # Le .env applicatif n'est pas produit par ce dépôt : il est déposé à la main
-# sur le serveur. Sur une machine neuve il n'existe pas encore, et l'alerte doit
-# le dire au lieu de faire échouer tout le bootstrap.
-- name: Check that the application environment file exists
-  ansible.builtin.stat:
-    path: "{{ alerting_dsn_source }}"
-  register: alerting_dsn_source_stat
+# sur le serveur. Sur une machine neuve il n'existe pas encore.
+# `failed_when: false` : une configuration d'alerte incomplète ne doit pas
+# interrompre le déploiement de l'application — le mécanisme censé signaler les
+# pannes serait alors lui-même une panne. L'échec n'est pas avalé pour autant :
+# il est rapporté juste en dessous, et l'auto-contrôle de fin de rôle le redit.
 - name: Copy the Sentry DSN into the alerting environment file
-  when: alerting_dsn_source_stat.stat.exists
+  when: alerting_dsn_source | length > 0
   ansible.builtin.command:
     cmd: "{{ alerting_dsn_sync_script_path }}"
   register: alerting_dsn_sync
   changed_when: "'DSN mis à jour.' in alerting_dsn_sync.stdout"
-- name: Report a missing DSN source
-  when: not alerting_dsn_source_stat.stat.exists
+  failed_when: false
+- name: Report a DSN that could not be copied
+  when:
+    - alerting_dsn_source | length > 0
+    - alerting_dsn_sync.rc != 0
   ansible.builtin.debug:
     msg: >-
-      [WARNING] {{ alerting_dsn_source }} est absent : SENTRY_CRON_DSN n'a pas pu être
-      recopié dans {{ alerting_env_file }}. Les unités d'alerte échoueront bruyamment
-      tant que ce fichier n'existe pas. Le déposer puis rejouer bootstrap.yaml.
+      [WARNING] SENTRY_CRON_DSN n'a pas pu être recopié dans {{ alerting_env_file }} :
+      {{ alerting_dsn_sync.stderr | default('') }}
+      Les unités d'alerte échoueront bruyamment tant que ce sera le cas.
+      Corriger {{ alerting_dsn_source }} puis rejouer bootstrap.yaml.
 - name: Install systemd failure alerting script
   ansible.builtin.template:
     src: templates/alerting/alert_systemd_failure.sh.j2
@@ -52,6 +71,7 @@
     owner: root
     group: root
     mode: "0700"
+  register: alerting_script
 - name: Setup systemd failure alerting service template
   ansible.builtin.template:
     src: templates/alerting/alert-systemd-failure@.service.j2
@@ -59,6 +79,7 @@
     owner: root
     group: root
     mode: "0644"
+  register: alerting_failure_unit
   notify: Reload systemd
 - name: Setup systemd sweep service
   ansible.builtin.template:
@@ -67,6 +88,7 @@
     owner: root
     group: root
     mode: "0644"
+  register: alerting_sweep_unit
   notify: Reload systemd
 - name: Setup systemd sweep timer
   ansible.builtin.template:
@@ -109,3 +131,34 @@
     name: "{{ alerting_sweep_service_name }}.timer"
     enabled: true
     state: started
+# Une chaîne d'alerte qui s'installe « tout vert » sur une machine où rien ne
+# partira jamais reproduit exactement le silence qu'elle est censée casser. Le
+# seul contrôle qui vaille est d'émettre réellement un événement et de regarder
+# s'il part.
+# Il ne tourne pas à chaque déploiement — un événement Sentry par déploiement
+# rouvrirait un ticket à chaque fois — mais dès que quelque chose a bougé, ou
+# quand le fichier d'environnement manque, c'est-à-dire dans tous les cas où la
+# chaîne peut être cassée sans qu'on le sache.
+- name: Check whether the alerting environment file is in place
+  ansible.builtin.stat:
+    path: "{{ alerting_env_file }}"
+  register: alerting_env_file_stat
+- name: Verify that an alert can actually reach Sentry
+  when: >-
+    not alerting_env_file_stat.stat.exists
+    or (alerting_dsn_sync is defined and alerting_dsn_sync is changed)
+    or alerting_script is changed
+    or alerting_failure_unit is changed
+    or alerting_sweep_unit is changed
+  ansible.builtin.command:
+    cmd: "{{ alerting_script_path }} --self-test"
+  register: alerting_self_test
+  changed_when: false
+  failed_when: false
+- name: Report an alerting chain that cannot reach Sentry
+  when: alerting_self_test.rc | default(0) != 0
+  ansible.builtin.debug:
+    msg: >-
+      [WARNING] L'auto-contrôle a échoué : aucun événement n'a pu être émis vers Sentry.
+      {{ alerting_self_test.stderr | default('') }}
+      Les unités systemd en échec ne seront signalées à personne tant que ce sera le cas.

--- a/roles/bootstrap/templates/alerting/alert-systemd-failure@.service.j2
+++ b/roles/bootstrap/templates/alerting/alert-systemd-failure@.service.j2
@@ -18,6 +18,11 @@ Group=root
 EnvironmentFile=-{{ alerting_env_file }}
 ExecStart={{ alerting_script_path }} %i
 
+# Sans délai de garde, un `Type=oneshot` hérite de `infinity` : une connexion
+# acceptée mais jamais répondue laisserait une instance figée en root pour chaque
+# unité qui tombe. Un seul événement à émettre ici, d'où une borne courte.
+TimeoutStartSec=120
+
 # Le service ne fait que lire l'état de systemd, le journal, et un fichier
 # d'environnement dans /etc. Il n'écrit nulle part.
 ProtectSystem=strict

--- a/roles/bootstrap/templates/alerting/alert-systemd-failure@.service.j2
+++ b/roles/bootstrap/templates/alerting/alert-systemd-failure@.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=Signale à Sentry l'échec de %i
+Documentation=https://github.com/betagouv/aides-jeunes-ops
+# Pas de `OnFailure=` ici : une alerte qui échoue et qui s'alerte elle-même
+# tourne en rond. Son échec la laisse en `failed`, et c'est le balayage
+# quotidien qui le remonte.
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart={{ alerting_script_path }} %i
+
+# Le service ne fait que lire l'état de systemd, le journal, et un fichier
+# d'environnement dans /etc. Il n'écrit nulle part.
+ProtectSystem=strict
+# En particulier : il n'a pas à lire les .env applicatifs, qui appartiennent à
+# l'utilisateur de déploiement. Le DSN lui arrive par {{ alerting_env_file }},
+# recopié par ansible et fermé en 0600 root:root.
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+# Pas de section [Install] : ce gabarit n'est instancié que par le `OnFailure=`
+# des unités surveillées.

--- a/roles/bootstrap/templates/alerting/alert-systemd-failure@.service.j2
+++ b/roles/bootstrap/templates/alerting/alert-systemd-failure@.service.j2
@@ -9,6 +9,13 @@ Documentation=https://github.com/betagouv/aides-jeunes-ops
 Type=oneshot
 User=root
 Group=root
+# Le DSN entre par systemd, qui analyse ce fichier lui-même : aucune évaluation
+# par un interpréteur de commandes, donc rien à substituer pour qui aurait
+# glissé un `$(…)` dans le .env dont ce fichier dérive.
+# Le préfixe « - » rend le fichier facultatif : absent, c'est le script qui le
+# dit avec un message exploitable, plutôt qu'un « Failed to load environment
+# files » de systemd. L'unité tombe en échec dans les deux cas.
+EnvironmentFile=-{{ alerting_env_file }}
 ExecStart={{ alerting_script_path }} %i
 
 # Le service ne fait que lire l'état de systemd, le journal, et un fichier

--- a/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
+++ b/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
@@ -20,7 +20,11 @@ ExecStart={{ alerting_script_path }} --sweep
 # 120 s de marge fixe. La figer en dur tronquerait le balayage dès qu'on relève
 # le plafond, et le tronquerait en `timeout`, c'est-à-dire en taisant les unités
 # restantes.
-TimeoutStartSec={{ (alerting_sweep_max_events | int) * 40 + 120 }}
+# Le plafond est borné à [1, 500] avant multiplication : `| int` rend 0 sur une
+# entrée non numérique, et une valeur négative donnerait un délai nul ou négatif
+# — que systemd lit « infinity », c'est-à-dire exactement le mode de panne que
+# cette ligne existe pour fermer.
+TimeoutStartSec={{ ([[alerting_sweep_max_events | int(10), 1] | max, 500] | min) * 40 + 120 }}
 
 ProtectSystem=strict
 ProtectHome=true

--- a/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
+++ b/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
@@ -6,6 +6,9 @@ Documentation=https://github.com/betagouv/aides-jeunes-ops
 Type=oneshot
 User=root
 Group=root
+# Voir alert-systemd-failure@.service.j2 : systemd analyse ce fichier lui-même,
+# sans interpréteur de commandes.
+EnvironmentFile=-{{ alerting_env_file }}
 ExecStart={{ alerting_script_path }} --sweep
 
 ProtectSystem=strict

--- a/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
+++ b/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=Balayage de l'état des unités systemd de {{ instance_name }}
+Documentation=https://github.com/betagouv/aides-jeunes-ops
+
+[Service]
+Type=oneshot
+User=root
+Group=root
+ExecStart={{ alerting_script_path }} --sweep
+
+ProtectSystem=strict
+ProtectHome=true
+PrivateTmp=true
+NoNewPrivileges=true
+ProtectKernelTunables=true
+ProtectControlGroups=true
+RestrictSUIDSGID=true
+
+# Pas de section [Install] : ce service est déclenché par son timer, et par lui
+# seul. Un `WantedBy=multi-user.target` lancerait un balayage à chaque
+# démarrage, au moment où la moitié des unités sont encore en cours de
+# démarrage.

--- a/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
+++ b/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
@@ -15,9 +15,12 @@ ExecStart={{ alerting_script_path }} --sweep
 # sur une connexion acceptée mais jamais répondue resterait « activating » pour
 # toujours, et systemd fusionnerait le déclenchement du lendemain dans le job en
 # cours : l'alerte s'arrêterait définitivement, sans jamais passer en `failed`.
-# 600 s couvre le pire cas légitime — le plafond d'événements multiplié par le
-# délai de garde de sentry-cli — avec de la marge.
-TimeoutStartSec=600
+# La borne dérive du plafond d'événements, qui est un bouton documenté : 40 s par
+# événement — le délai de garde de sentry-cli plus la lecture du journal — et
+# 120 s de marge fixe. La figer en dur tronquerait le balayage dès qu'on relève
+# le plafond, et le tronquerait en `timeout`, c'est-à-dire en taisant les unités
+# restantes.
+TimeoutStartSec={{ (alerting_sweep_max_events | int) * 40 + 120 }}
 
 ProtectSystem=strict
 ProtectHome=true

--- a/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
+++ b/roles/bootstrap/templates/alerting/alert-systemd-sweep.service.j2
@@ -11,6 +11,14 @@ Group=root
 EnvironmentFile=-{{ alerting_env_file }}
 ExecStart={{ alerting_script_path }} --sweep
 
+# Un `Type=oneshot` sans délai de garde hérite de `infinity`. Un balayage figé
+# sur une connexion acceptée mais jamais répondue resterait « activating » pour
+# toujours, et systemd fusionnerait le déclenchement du lendemain dans le job en
+# cours : l'alerte s'arrêterait définitivement, sans jamais passer en `failed`.
+# 600 s couvre le pire cas légitime — le plafond d'événements multiplié par le
+# délai de garde de sentry-cli — avec de la marge.
+TimeoutStartSec=600
+
 ProtectSystem=strict
 ProtectHome=true
 PrivateTmp=true

--- a/roles/bootstrap/templates/alerting/alert-systemd-sweep.timer.j2
+++ b/roles/bootstrap/templates/alerting/alert-systemd-sweep.timer.j2
@@ -1,0 +1,13 @@
+[Unit]
+Description=Déclenche le balayage quotidien des unités systemd de {{ instance_name }}
+
+[Timer]
+OnCalendar={{ alerting_sweep_on_calendar }}
+# Rattrape le balayage manqué si la machine était éteinte à l'heure prévue :
+# une panne survenue pendant l'arrêt est justement celle qu'on veut voir.
+Persistent=true
+AccuracySec=1min
+Unit={{ alerting_sweep_service_name }}.service
+
+[Install]
+WantedBy=timers.target

--- a/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
+++ b/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
@@ -89,10 +89,19 @@ unit_property() {
   systemctl show "$1" --property="$2" --value
 }
 
+# Comparaison de chaînes, et non filtrage par motif : un nom d'unité peut porter
+# une échappée systemd (« var-lib\x2ddocker.mount »), et le contre-oblique
+# ferait rater la reconnaissance dans un motif `case` — d'où journal non joint et
+# double émission pour la même unité.
 in_list() {
-  case " $2 " in
-    *" $1 "*) return 0 ;;
-  esac
+  local needle="$1"
+  local item
+  # shellcheck disable=SC2086 # découpage voulu : un nom d'unité n'a pas d'espace
+  for item in $2; do
+    if [ "$item" = "$needle" ]; then
+      return 0
+    fi
+  done
   return 1
 }
 
@@ -128,7 +137,7 @@ send_event() {
   # --no-environ : sans ce drapeau, sentry-cli joint l'environnement du
   # processus à l'événement. Ce script tourne en root et porte un DSN.
   status=0
-  SENTRY_DSN="$SENTRY_DSN" timeout "$sentry_timeout_seconds" sentry-cli send-event \
+  SENTRY_DSN="$SENTRY_DSN" timeout -k 5 "$sentry_timeout_seconds" sentry-cli send-event \
     --no-environ \
     --level error \
     --message "$summary" \
@@ -232,7 +241,7 @@ sweep() {
 # une machine où aucune alerte ne partira jamais — soit exactement le silence
 # qu'il est censé casser.
 self_test() {
-  SENTRY_DSN="$SENTRY_DSN" timeout "$sentry_timeout_seconds" sentry-cli send-event \
+  SENTRY_DSN="$SENTRY_DSN" timeout -k 5 "$sentry_timeout_seconds" sentry-cli send-event \
     --no-environ \
     --level info \
     --message "systemd : chaîne d'alerte installée et joignable — $hostname_fqdn" \

--- a/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
+++ b/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
@@ -4,10 +4,11 @@
 
 # Pousse un événement Sentry pour chaque unité systemd en défaut.
 #
-#   alert_systemd_failure.sh <unité>   une unité nommée, appelé par `OnFailure=`
-#   alert_systemd_failure.sh --sweep   balayage de l'état du système, quotidien
+#   alert_systemd_failure.sh <unité>     une unité nommée, appelé par `OnFailure=`
+#   alert_systemd_failure.sh --sweep     balayage de l'état du système, quotidien
+#   alert_systemd_failure.sh --self-test émet un événement de contrôle et sort
 #
-# Les deux modes existent parce qu'ils n'attrapent pas la même chose.
+# Les deux premiers modes existent parce qu'ils n'attrapent pas la même chose.
 # `OnFailure=` réagit à une *transition* : il alerte à la seconde où l'unité
 # tombe, et seulement à ce moment-là. Le balayage lit un *état* : il retrouve
 # une unité tombée avant l'installation du mécanisme, une unité arrêtée qui
@@ -23,12 +24,20 @@ set -euo pipefail
 env_file="{{ alerting_env_file }}"
 instance="{{ instance_name }}"
 max_events={{ alerting_sweep_max_events }}
-# Unités dont on attend qu'elles tournent. Un service déclenché par un timer
-# n'y figure pas : son état normal est « inactive ».
-# Test sur la concaténation et non sur le cardinal du tableau : la syntaxe bash
-# du cardinal accole une accolade et un dièse, que Jinja lit comme une
-# ouverture de commentaire — le gabarit ne se rendrait plus du tout.
-watched_active=({% for unit in alerting_watched_units if unit.expect_active %}"{{ unit.name }}" {% endfor %})
+# Listes plates, séparées par des espaces : un nom d'unité systemd ne contient
+# jamais d'espace. Un tableau bash obligerait à écrire son cardinal, dont la
+# syntaxe accole une accolade et un dièse que Jinja lit comme une ouverture de
+# commentaire — le gabarit ne se rendrait alors plus du tout.
+watched_units="{{ alerting_watched_units | map(attribute='name') | join(' ') }}"
+# Unités dont on attend qu'elles tournent. Un service déclenché par un timer n'y
+# figure pas : son état normal est « inactive ».
+watched_active="{{ alerting_watched_units | selectattr('expect_active') | map(attribute='name') | join(' ') }}"
+
+# État du balayage. Volontairement global : `emit` doit pouvoir le faire avancer.
+emitted_units=""
+emitted_count=0
+skipped_count=0
+send_status=0
 
 fail() {
   printf 'ALERTE SYSTEMD IMPOSSIBLE : %s\n' "$1" >&2
@@ -38,13 +47,19 @@ fail() {
 command -v sentry-cli >/dev/null ||
   fail "sentry-cli est introuvable, aucun événement ne peut partir"
 
-if [ ! -r "$env_file" ]; then
-  fail "$env_file est absent ou illisible — rejouer bootstrap.yaml pour le réinstaller"
-fi
-# Fichier écrit par ansible, root:root 0600, et ne contenant que SENTRY_DSN.
-# shellcheck disable=SC1090
-. "$env_file"
+# Le DSN arrive normalement par `EnvironmentFile=` : systemd analyse le fichier
+# lui-même, sans interpréteur de commandes. Pour une exécution à la main, on le
+# relit ici — par extraction, JAMAIS par `source`. Le fichier dérive du .env
+# applicatif, que possède l'utilisateur de déploiement : le sourcer rendrait à
+# ce dernier l'exécution de code en root que l'extraction lui refuse côté
+# synchronisation.
 if [ -z "${SENTRY_DSN:-}" ]; then
+  if [ ! -r "$env_file" ]; then
+    fail "$env_file est absent ou illisible — rejouer bootstrap.yaml pour le réinstaller"
+  fi
+  SENTRY_DSN="$(sed -n 's/^SENTRY_DSN=//p' "$env_file" | head -n 1)"
+fi
+if [ -z "$SENTRY_DSN" ]; then
   fail "SENTRY_DSN est absent de $env_file"
 fi
 
@@ -54,6 +69,13 @@ unit_property() {
   systemctl show "$1" --property="$2" --value
 }
 
+in_list() {
+  case " $2 " in
+    *" $1 "*) return 0 ;;
+  esac
+  return 1
+}
+
 # Un événement par unité, empreinte stable : Sentry regroupe toutes les alertes
 # d'une même unité dans un seul ticket, qu'on résout quand la panne est traitée.
 # Le détail volatil (journal, code de sortie) part en pièces jointes et non dans
@@ -61,19 +83,30 @@ unit_property() {
 send_event() {
   local unit="$1"
   local summary="$2"
-  local journal
+  local journal=""
   local status
+  local journal_args=()
 
-  journal="$(mktemp)"
-  # Le journal de l'unité porte la cause réelle : la ligne de mongodump qui a
-  # échoué, la trace du crash au démarrage. Sans elle, l'alerte oblige à se
-  # connecter à la machine pour apprendre quoi que ce soit.
-  if ! journalctl --unit "$unit" --lines=50 --no-pager --output=short-iso >"$journal" 2>&1; then
-    printf 'journalctl a échoué pour %s, journal indisponible\n' "$unit" >>"$journal"
+  # MINIMISATION : le journal ne suit que pour les unités déclarées dans
+  # `alerting_watched_units`. Le balayage remonte aussi les unités que personne
+  # n'a listées — les services applicatifs et openfisca en font partie, et leur
+  # journal peut porter des données personnelles ou financières. Pour celles-là
+  # on signale l'échec, sans en exporter le contenu vers Sentry.
+  if in_list "$unit" "$watched_units"; then
+    journal="$(mktemp)"
+    # Le journal de l'unité porte la cause réelle : la ligne de mongodump qui a
+    # échoué, la trace du crash au démarrage. Sans elle, l'alerte oblige à se
+    # connecter à la machine pour apprendre quoi que ce soit.
+    if ! journalctl --unit "$unit" --lines=50 --no-pager --output=short-iso >"$journal" 2>&1; then
+      printf 'journalctl a échoué pour %s, journal indisponible\n' "$unit" >>"$journal"
+    fi
+    journal_args=(--logfile "$journal")
+  else
+    journal_args=(--extra "journal:non joint, unité hors de alerting_watched_units")
   fi
 
   # --no-environ : sans ce drapeau, sentry-cli joint l'environnement du
-  # processus à l'événement. Ce script tourne en root et a chargé un DSN.
+  # processus à l'événement. Ce script tourne en root et porte un DSN.
   status=0
   SENTRY_DSN="$SENTRY_DSN" sentry-cli send-event \
     --no-environ \
@@ -89,9 +122,11 @@ send_event() {
     --extra "sub_state:$(unit_property "$unit" SubState)" \
     --extra "result:$(unit_property "$unit" Result)" \
     --extra "exec_main_status:$(unit_property "$unit" ExecMainStatus)" \
-    --logfile "$journal" || status=$?
+    "${journal_args[@]}" || status=$?
 
-  rm -f "$journal"
+  if [ -n "$journal" ]; then
+    rm -f "$journal"
+  fi
 
   if [ "$status" -ne 0 ]; then
     printf 'sentry-cli a échoué (code %s) pour %s\n' "$status" "$unit" >&2
@@ -100,17 +135,53 @@ send_event() {
   printf 'Événement Sentry émis pour %s : %s\n' "$unit" "$summary"
 }
 
+# Déduplication et plafond, en un seul endroit. Une unité peut être vue deux
+# fois — déclarée *et* présente dans `systemctl --failed` — et ne doit pas
+# ouvrir deux fois le même ticket ni consommer deux fois le budget.
+emit() {
+  local unit="$1"
+  local summary="$2"
+
+  if in_list "$unit" "$emitted_units"; then
+    return 0
+  fi
+  if [ "$emitted_count" -ge "$max_events" ]; then
+    skipped_count=$((skipped_count + 1))
+    return 0
+  fi
+  emitted_units="$emitted_units $unit"
+  emitted_count=$((emitted_count + 1))
+  send_event "$unit" "$summary" || send_status=1
+}
+
 sweep() {
-  local sent=0
-  local failed_total=0
   local unit
   local state
-  local send_status=0
   local failed_units
 
-  # Toutes les unités en échec, pas seulement celles qu'on a pensé à lister :
-  # c'est ce qui couvre les services openfisca, dont le nom dépend de
-  # l'inventaire, et tout ce qui sera ajouté à la machine plus tard.
+  # LES UNITÉS DÉCLARÉES D'ABORD. `systemctl` rend sa liste par ordre
+  # alphabétique : une salve d'unités « alert-systemd-failure@… » ou de services
+  # de test trie en tête et mangerait tout le plafond avant qu'on arrive à
+  # nginx. Ce qu'on a explicitement demandé à surveiller passe donc en premier,
+  # quoi qu'il arrive par ailleurs.
+  # Ce passage attrape aussi le mode de panne muet : une unité arrêtée, jamais
+  # démarrée, ou dont le fichier a disparu n'est pas « en échec », elle est
+  # simplement absente — aucune requête globale ne peut la deviner.
+  if [ -n "$watched_units" ]; then
+    # shellcheck disable=SC2086 # découpage voulu : un nom d'unité n'a pas d'espace
+    for unit in $watched_units; do
+      state="$(unit_property "$unit" ActiveState)"
+      if [ "$state" = "failed" ]; then
+        emit "$unit" "systemd : unité en échec — $unit"
+      elif in_list "$unit" "$watched_active" && [ "$state" != "active" ]; then
+        emit "$unit" "systemd : unité attendue active, état « $state » — $unit"
+      fi
+    done
+  fi
+
+  # Puis tout le reste de ce qui est en échec, y compris ce que personne n'a
+  # pensé à lister : les services openfisca, dont le nom dépend de l'inventaire,
+  # et tout ce qui sera ajouté à la machine plus tard.
   # `--plain` retire la puce que systemd place devant une unité en échec, sans
   # quoi le nom lu serait « ● ».
   failed_units="$(systemctl list-units --state=failed --all --no-legend --plain)" ||
@@ -118,36 +189,15 @@ sweep() {
 
   while read -r unit _; do
     [ -n "$unit" ] || continue
-    failed_total=$((failed_total + 1))
-    if [ "$sent" -ge "$max_events" ]; then
-      continue
-    fi
-    send_event "$unit" "systemd : unité en échec — $unit" || send_status=1
-    sent=$((sent + 1))
+    emit "$unit" "systemd : unité en échec — $unit"
   done <<<"$failed_units"
 
-  if [ "$failed_total" -gt "$max_events" ]; then
-    printf '%s unités en échec, seules les %s premières ont été remontées.\n' \
-      "$failed_total" "$max_events" >&2
+  if [ "$skipped_count" -gt 0 ]; then
+    printf 'Plafond de %s événements atteint : %s unité(s) en défaut non remontée(s) individuellement.\n' \
+      "$max_events" "$skipped_count" >&2
   fi
 
-  # Une unité arrêtée, jamais démarrée, ou dont le fichier a disparu n'est pas
-  # « en échec » : elle est simplement absente. C'est un mode de panne muet, et
-  # le seul contrôle qui l'attrape est celui-ci.
-  if [ -n "${watched_active[*]}" ]; then
-    for unit in "${watched_active[@]}"; do
-      state="$(unit_property "$unit" ActiveState)"
-      # `failed` est déjà remonté par le balayage ci-dessus.
-      if [ "$state" = "active" ] || [ "$state" = "failed" ]; then
-        continue
-      fi
-      send_event "$unit" "systemd : unité attendue active, état « $state » — $unit" ||
-        send_status=1
-      sent=$((sent + 1))
-    done
-  fi
-
-  if [ "$sent" -eq 0 ]; then
+  if [ "$emitted_count" -eq 0 ]; then
     printf 'Balayage systemd : aucune unité en défaut.\n'
   fi
 
@@ -157,15 +207,33 @@ sweep() {
   return "$send_status"
 }
 
+# Prouve que la chaîne entière fonctionne : DSN lisible, sentry-cli présent,
+# Sentry joignable. Sans ce contrôle, le mécanisme s'installe « tout vert » sur
+# une machine où aucune alerte ne partira jamais — soit exactement le silence
+# qu'il est censé casser.
+self_test() {
+  SENTRY_DSN="$SENTRY_DSN" sentry-cli send-event \
+    --no-environ \
+    --level info \
+    --message "systemd : chaîne d'alerte installée et joignable — $hostname_fqdn" \
+    --fingerprint "systemd-alerting-self-test" \
+    --tag "instance:$instance" \
+    --tag "host:$hostname_fqdn"
+  printf 'Auto-contrôle : un événement Sentry est effectivement parti.\n'
+}
+
 case "${1:-}" in
   --sweep)
     sweep
     ;;
+  --self-test)
+    self_test
+    ;;
   "")
-    fail "aucun argument : attendu une unité systemd ou --sweep"
+    fail "aucun argument : attendu une unité systemd, --sweep ou --self-test"
     ;;
   -*)
-    fail "option inconnue « $1 » : attendu une unité systemd ou --sweep"
+    fail "option inconnue « $1 » : attendu une unité systemd, --sweep ou --self-test"
     ;;
   *)
     send_event "$1" "systemd : unité en échec — $1"

--- a/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
+++ b/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
@@ -89,20 +89,20 @@ unit_property() {
   systemctl show "$1" --property="$2" --value
 }
 
-# Comparaison de chaînes, et non filtrage par motif : un nom d'unité peut porter
-# une échappée systemd (« var-lib\x2ddocker.mount »), et le contre-oblique
-# ferait rater la reconnaissance dans un motif `case` — d'où journal non joint et
-# double émission pour la même unité.
+# Appartenance testée sans jamais interpréter le nom d'unité :
+#  - pas de motif `case`, un contre-oblique d'échappée systemd
+#    (« var-lib\x2ddocker.mount ») y ferait rater la reconnaissance ;
+#  - pas de boucle `for item in $2` non plus, qui soumettrait chaque élément à
+#    l'expansion de chemin — « a*b.service » reconnaîtrait « aXb.service » si un
+#    fichier de ce nom existait dans le répertoire courant.
+# Dans les deux cas la conséquence est la même : journal non joint et double
+# émission pour une même unité.
+# Ici seule l'étoile de tête est un motif ; la partie entre guillemets est
+# comparée littéralement.
 in_list() {
   local needle="$1"
-  local item
-  # shellcheck disable=SC2086 # découpage voulu : un nom d'unité n'a pas d'espace
-  for item in $2; do
-    if [ "$item" = "$needle" ]; then
-      return 0
-    fi
-  done
-  return 1
+  local haystack=" $2 "
+  [ "${haystack#*" $needle "}" != "$haystack" ]
 }
 
 # Un événement par unité, empreinte stable : Sentry regroupe toutes les alertes

--- a/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
+++ b/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
@@ -23,7 +23,13 @@ set -euo pipefail
 
 env_file="{{ alerting_env_file }}"
 instance="{{ instance_name }}"
-max_events={{ alerting_sweep_max_events }}
+max_events="{{ alerting_sweep_max_events }}"
+# Délai de garde de chaque appel à sentry-cli. Il n'a pas d'option pour cela, et
+# une connexion TCP acceptée mais jamais répondue — pare-feu à états, NAT, ingest
+# saturé — le laisse attendre indéfiniment. Sans ce garde-fou, le balayage reste
+# « activating » pour toujours, le déclenchement quotidien suivant est fusionné
+# dans le job en cours, et l'alerte s'arrête définitivement.
+sentry_timeout_seconds=30
 # Listes plates, séparées par des espaces : un nom d'unité systemd ne contient
 # jamais d'espace. Un tableau bash obligerait à écrire son cardinal, dont la
 # syntaxe accole une accolade et un dièse que Jinja lit comme une ouverture de
@@ -47,6 +53,16 @@ fail() {
 command -v sentry-cli >/dev/null ||
   fail "sentry-cli est introuvable, aucun événement ne peut partir"
 
+# Le plafond est comparé par `[ … -ge … ]` à l'intérieur d'un `if` : bash y rend
+# une erreur d'opérande sans que `set -e` n'intervienne, et une valeur non
+# numérique désactiverait donc le plafond en silence.
+case "$max_events" in
+  '' | *[!0-9]*) fail "plafond d'événements invalide ($max_events) : un entier est attendu" ;;
+esac
+if [ "$max_events" -lt 1 ]; then
+  fail "plafond d'événements invalide ($max_events) : au moins 1 est requis"
+fi
+
 # Le DSN arrive normalement par `EnvironmentFile=` : systemd analyse le fichier
 # lui-même, sans interpréteur de commandes. Pour une exécution à la main, on le
 # relit ici — par extraction, JAMAIS par `source`. Le fichier dérive du .env
@@ -54,10 +70,14 @@ command -v sentry-cli >/dev/null ||
 # ce dernier l'exécution de code en root que l'extraction lui refuse côté
 # synchronisation.
 if [ -z "${SENTRY_DSN:-}" ]; then
-  if [ ! -r "$env_file" ]; then
-    fail "$env_file est absent ou illisible — rejouer bootstrap.yaml pour le réinstaller"
+  # `-f` et pas seulement `-r` : un tube nommé déposé à cet emplacement est
+  # lisible et bloquerait la lecture indéfiniment, en root.
+  if [ ! -f "$env_file" ] || [ ! -r "$env_file" ]; then
+    fail "$env_file est absent, illisible ou n'est pas un fichier ordinaire — rejouer bootstrap.yaml"
   fi
-  SENTRY_DSN="$(sed -n 's/^SENTRY_DSN=//p' "$env_file" | head -n 1)"
+  # `tail` et non `head` : avec `pipefail`, un `head` qui ferme le tube tue `sed`
+  # par SIGPIPE et le script sortirait en 141 sans un mot.
+  SENTRY_DSN="$(sed -n 's/^SENTRY_DSN=//p' "$env_file" | tail -n 1)"
 fi
 if [ -z "$SENTRY_DSN" ]; then
   fail "SENTRY_DSN est absent de $env_file"
@@ -108,7 +128,7 @@ send_event() {
   # --no-environ : sans ce drapeau, sentry-cli joint l'environnement du
   # processus à l'événement. Ce script tourne en root et porte un DSN.
   status=0
-  SENTRY_DSN="$SENTRY_DSN" sentry-cli send-event \
+  SENTRY_DSN="$SENTRY_DSN" timeout "$sentry_timeout_seconds" sentry-cli send-event \
     --no-environ \
     --level error \
     --message "$summary" \
@@ -212,7 +232,7 @@ sweep() {
 # une machine où aucune alerte ne partira jamais — soit exactement le silence
 # qu'il est censé casser.
 self_test() {
-  SENTRY_DSN="$SENTRY_DSN" sentry-cli send-event \
+  SENTRY_DSN="$SENTRY_DSN" timeout "$sentry_timeout_seconds" sentry-cli send-event \
     --no-environ \
     --level info \
     --message "systemd : chaîne d'alerte installée et joignable — $hostname_fqdn" \

--- a/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
+++ b/roles/bootstrap/templates/alerting/alert_systemd_failure.sh.j2
@@ -1,0 +1,173 @@
+#!/bin/bash
+# MANAGED BY MES AIDES OPS
+# Modifications should be made in templates/alerting/alert_systemd_failure.sh.j2
+
+# Pousse un événement Sentry pour chaque unité systemd en défaut.
+#
+#   alert_systemd_failure.sh <unité>   une unité nommée, appelé par `OnFailure=`
+#   alert_systemd_failure.sh --sweep   balayage de l'état du système, quotidien
+#
+# Les deux modes existent parce qu'ils n'attrapent pas la même chose.
+# `OnFailure=` réagit à une *transition* : il alerte à la seconde où l'unité
+# tombe, et seulement à ce moment-là. Le balayage lit un *état* : il retrouve
+# une unité tombée avant l'installation du mécanisme, une unité arrêtée qui
+# aurait dû tourner, un timer disparu — et il redit chaque jour ce qui reste
+# cassé. Le service de supervision est resté en échec un an sans que la
+# transition, unique et passée, ne serve à personne.
+#
+# Toute anomalie sort en code non nul : l'unité d'alerte passe elle-même en
+# `failed`, ce que le balayage suivant remonte. Aucun repli silencieux.
+
+set -euo pipefail
+
+env_file="{{ alerting_env_file }}"
+instance="{{ instance_name }}"
+max_events={{ alerting_sweep_max_events }}
+# Unités dont on attend qu'elles tournent. Un service déclenché par un timer
+# n'y figure pas : son état normal est « inactive ».
+# Test sur la concaténation et non sur le cardinal du tableau : la syntaxe bash
+# du cardinal accole une accolade et un dièse, que Jinja lit comme une
+# ouverture de commentaire — le gabarit ne se rendrait plus du tout.
+watched_active=({% for unit in alerting_watched_units if unit.expect_active %}"{{ unit.name }}" {% endfor %})
+
+fail() {
+  printf 'ALERTE SYSTEMD IMPOSSIBLE : %s\n' "$1" >&2
+  exit 1
+}
+
+command -v sentry-cli >/dev/null ||
+  fail "sentry-cli est introuvable, aucun événement ne peut partir"
+
+if [ ! -r "$env_file" ]; then
+  fail "$env_file est absent ou illisible — rejouer bootstrap.yaml pour le réinstaller"
+fi
+# Fichier écrit par ansible, root:root 0600, et ne contenant que SENTRY_DSN.
+# shellcheck disable=SC1090
+. "$env_file"
+if [ -z "${SENTRY_DSN:-}" ]; then
+  fail "SENTRY_DSN est absent de $env_file"
+fi
+
+hostname_fqdn="$(uname -n)"
+
+unit_property() {
+  systemctl show "$1" --property="$2" --value
+}
+
+# Un événement par unité, empreinte stable : Sentry regroupe toutes les alertes
+# d'une même unité dans un seul ticket, qu'on résout quand la panne est traitée.
+# Le détail volatil (journal, code de sortie) part en pièces jointes et non dans
+# le message, sans quoi chaque exécution ouvrirait un ticket de plus.
+send_event() {
+  local unit="$1"
+  local summary="$2"
+  local journal
+  local status
+
+  journal="$(mktemp)"
+  # Le journal de l'unité porte la cause réelle : la ligne de mongodump qui a
+  # échoué, la trace du crash au démarrage. Sans elle, l'alerte oblige à se
+  # connecter à la machine pour apprendre quoi que ce soit.
+  if ! journalctl --unit "$unit" --lines=50 --no-pager --output=short-iso >"$journal" 2>&1; then
+    printf 'journalctl a échoué pour %s, journal indisponible\n' "$unit" >>"$journal"
+  fi
+
+  # --no-environ : sans ce drapeau, sentry-cli joint l'environnement du
+  # processus à l'événement. Ce script tourne en root et a chargé un DSN.
+  status=0
+  SENTRY_DSN="$SENTRY_DSN" sentry-cli send-event \
+    --no-environ \
+    --level error \
+    --message "$summary" \
+    --fingerprint "systemd-unit-failure" \
+    --fingerprint "$unit" \
+    --tag "unit:$unit" \
+    --tag "instance:$instance" \
+    --tag "host:$hostname_fqdn" \
+    --extra "load_state:$(unit_property "$unit" LoadState)" \
+    --extra "active_state:$(unit_property "$unit" ActiveState)" \
+    --extra "sub_state:$(unit_property "$unit" SubState)" \
+    --extra "result:$(unit_property "$unit" Result)" \
+    --extra "exec_main_status:$(unit_property "$unit" ExecMainStatus)" \
+    --logfile "$journal" || status=$?
+
+  rm -f "$journal"
+
+  if [ "$status" -ne 0 ]; then
+    printf 'sentry-cli a échoué (code %s) pour %s\n' "$status" "$unit" >&2
+    return "$status"
+  fi
+  printf 'Événement Sentry émis pour %s : %s\n' "$unit" "$summary"
+}
+
+sweep() {
+  local sent=0
+  local failed_total=0
+  local unit
+  local state
+  local send_status=0
+  local failed_units
+
+  # Toutes les unités en échec, pas seulement celles qu'on a pensé à lister :
+  # c'est ce qui couvre les services openfisca, dont le nom dépend de
+  # l'inventaire, et tout ce qui sera ajouté à la machine plus tard.
+  # `--plain` retire la puce que systemd place devant une unité en échec, sans
+  # quoi le nom lu serait « ● ».
+  failed_units="$(systemctl list-units --state=failed --all --no-legend --plain)" ||
+    fail "systemctl list-units a échoué, impossible de connaître l'état du système"
+
+  while read -r unit _; do
+    [ -n "$unit" ] || continue
+    failed_total=$((failed_total + 1))
+    if [ "$sent" -ge "$max_events" ]; then
+      continue
+    fi
+    send_event "$unit" "systemd : unité en échec — $unit" || send_status=1
+    sent=$((sent + 1))
+  done <<<"$failed_units"
+
+  if [ "$failed_total" -gt "$max_events" ]; then
+    printf '%s unités en échec, seules les %s premières ont été remontées.\n' \
+      "$failed_total" "$max_events" >&2
+  fi
+
+  # Une unité arrêtée, jamais démarrée, ou dont le fichier a disparu n'est pas
+  # « en échec » : elle est simplement absente. C'est un mode de panne muet, et
+  # le seul contrôle qui l'attrape est celui-ci.
+  if [ -n "${watched_active[*]}" ]; then
+    for unit in "${watched_active[@]}"; do
+      state="$(unit_property "$unit" ActiveState)"
+      # `failed` est déjà remonté par le balayage ci-dessus.
+      if [ "$state" = "active" ] || [ "$state" = "failed" ]; then
+        continue
+      fi
+      send_event "$unit" "systemd : unité attendue active, état « $state » — $unit" ||
+        send_status=1
+      sent=$((sent + 1))
+    done
+  fi
+
+  if [ "$sent" -eq 0 ]; then
+    printf 'Balayage systemd : aucune unité en défaut.\n'
+  fi
+
+  # Le balayage ne rend un code non nul que si *l'émission* a échoué. Signaler
+  # une panne n'est pas en être une : sortir en erreur ici mettrait le balayage
+  # en échec et le ferait s'alerter lui-même en boucle.
+  return "$send_status"
+}
+
+case "${1:-}" in
+  --sweep)
+    sweep
+    ;;
+  "")
+    fail "aucun argument : attendu une unité systemd ou --sweep"
+    ;;
+  -*)
+    fail "option inconnue « $1 » : attendu une unité systemd ou --sweep"
+    ;;
+  *)
+    send_event "$1" "systemd : unité en échec — $1"
+    ;;
+esac

--- a/roles/bootstrap/templates/alerting/onfailure.conf.j2
+++ b/roles/bootstrap/templates/alerting/onfailure.conf.j2
@@ -1,0 +1,10 @@
+# MANAGED BY MES AIDES OPS
+# Modifications should be made in templates/alerting/onfailure.conf.j2
+
+# Greffon, et non modification de l'unité elle-même : le même fichier se pose
+# sur une unité de ce dépôt comme sur une unité de distribution (nginx, mongod)
+# sans jamais toucher à sa définition d'origine.
+# `%n` est le nom de l'unité qui tombe ; il devient l'instance du gabarit
+# d'alerte, qui le relit dans `%i`.
+[Unit]
+OnFailure={{ alerting_failure_service_name }}@%n.service

--- a/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
+++ b/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
@@ -1,0 +1,72 @@
+#!/bin/bash
+# MANAGED BY MES AIDES OPS
+# Modifications should be made in templates/alerting/sync_alerting_dsn.sh.j2
+
+# Recopie le seul SENTRY_CRON_DSN du .env applicatif vers un fichier
+# d'environnement fermé (0600 root:root), d'où les unités d'alerte le liront.
+#
+# Le DSN n'existe nulle part dans ce dépôt et ne transite par aucune variable
+# ansible : ce script tourne sur la machine, lit la valeur là où elle est déjà,
+# et ne l'affiche jamais.
+
+set -euo pipefail
+umask 0077
+
+source_env="{{ alerting_dsn_source }}"
+target_env="{{ alerting_env_file }}"
+
+fail() {
+  printf 'SYNCHRONISATION DU DSN SENTRY IMPOSSIBLE : %s\n' "$1" >&2
+  exit 1
+}
+
+if [ ! -r "$source_env" ]; then
+  fail "$source_env est absent ou illisible"
+fi
+
+# `sed` plutôt que `source` : le .env appartient à l'utilisateur de déploiement
+# et ce script tourne en root. Le sourcer donnerait une exécution de code en
+# root à quiconque peut écrire ce fichier, et importerait au passage tous les
+# autres secrets applicatifs dans l'environnement du processus.
+# La dernière affectation gagne, comme le ferait un interpréteur de .env.
+dsn="$(
+  sed -n \
+    -e 's/^[[:space:]]*//' \
+    -e 's/^export[[:space:]]\{1,\}//' \
+    -e 's/^SENTRY_CRON_DSN[[:space:]]*=[[:space:]]*//p' \
+    "$source_env" | tail -n 1
+)"
+
+# Retrait du retour chariot d'un fichier édité sous Windows, puis des
+# guillemets éventuels autour de la valeur.
+dsn="${dsn%$'\r'}"
+dsn="${dsn%\"}"
+dsn="${dsn#\"}"
+dsn="${dsn%\'}"
+dsn="${dsn#\'}"
+
+# Contrôle de forme, sans jamais afficher la valeur : un DSN Sentry est une URL.
+# Sans ce contrôle, une ligne commentée ou une valeur vide produirait un fichier
+# d'alerte syntaxiquement correct dont le seul effet serait de faire échouer
+# chaque alerte, au moment précis où on en a besoin.
+case "$dsn" in
+  https://*@*/* | http://*@*/*) ;;
+  "") fail "SENTRY_CRON_DSN est absent ou vide dans $source_env" ;;
+  *) fail "SENTRY_CRON_DSN de $source_env n'a pas la forme d'un DSN Sentry" ;;
+esac
+
+candidate="$target_env.candidate"
+printf 'SENTRY_DSN=%s\n' "$dsn" >"$candidate"
+chmod 0600 "$candidate"
+chown root:root "$candidate"
+
+# Écriture uniquement si la valeur a bougé : ansible reste idempotent, et le
+# fichier ne change pas d'horodatage à chaque déploiement.
+if cmp -s "$candidate" "$target_env"; then
+  rm -f "$candidate"
+  printf 'DSN inchangé.\n'
+  exit 0
+fi
+
+mv "$candidate" "$target_env"
+printf 'DSN mis à jour.\n'

--- a/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
+++ b/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
@@ -100,6 +100,19 @@ case "$key" in
     ;;
 esac
 
+# L'alphabet ne borne pas la taille : une clé démesurée passerait ici et ne se
+# verrait qu'à l'émission, en « http status: 431 » puis, au-delà d'environ
+# 131 ko, en « 203/EXEC — Argument list too long ». Bruyant, mais trois tâches
+# trop loin — le message appartient ici. Une clé publique Sentry fait 32
+# caractères, 128 laisse de la marge à tout format à venir.
+# `wc -c` et non la syntaxe bash du cardinal : celle-ci accole une accolade et un
+# dièse, que Jinja lit comme une ouverture de commentaire — le gabarit ne se
+# rendrait alors plus du tout.
+key_length="$(printf '%s' "$key" | wc -c)"
+if [ "$key_length" -gt 128 ]; then
+  fail "la clé publique de SENTRY_CRON_DSN ($source_env) fait $key_length caractères, 128 au plus"
+fi
+
 # Composition, et non recopie : les trois morceaux sont assemblés ici, deux
 # venant du dépôt et un seul du .env.
 dsn="$scheme://$key@$destination"

--- a/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
+++ b/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
@@ -37,21 +37,44 @@ dsn="$(
     "$source_env" | tail -n 1
 )"
 
-# Retrait du retour chariot d'un fichier édité sous Windows, puis des
-# guillemets éventuels autour de la valeur.
-dsn="${dsn%$'\r'}"
-dsn="${dsn%\"}"
-dsn="${dsn#\"}"
-dsn="${dsn%\'}"
-dsn="${dsn#\'}"
+trim() {
+  printf '%s' "$1" | tr -d '\r' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//'
+}
 
-# Contrôle de forme, sans jamais afficher la valeur : un DSN Sentry est une URL.
-# Sans ce contrôle, une ligne commentée ou une valeur vide produirait un fichier
-# d'alerte syntaxiquement correct dont le seul effet serait de faire échouer
-# chaque alerte, au moment précis où on en a besoin.
+# ORDRE IMPORTANT : les espaces de fin d'abord, les guillemets ensuite, puis de
+# nouveau les espaces qui étaient à l'intérieur des guillemets. Retirer les
+# guillemets en premier laisse le guillemet fermant collé à la valeur dès que la
+# ligne du .env se termine par une espace — invisible à la lecture, et le
+# fichier produit désarmerait alors chaque alerte sans que rien ne le signale.
+dsn="$(trim "$dsn")"
 case "$dsn" in
-  https://*@*/* | http://*@*/*) ;;
+  \"*\")
+    dsn="${dsn%\"}"
+    dsn="${dsn#\"}"
+    ;;
+  \'*\')
+    dsn="${dsn%\'}"
+    dsn="${dsn#\'}"
+    ;;
+esac
+dsn="$(trim "$dsn")"
+
+# Contrôle de jeu de caractères et de forme, sans jamais afficher la valeur.
+# Le jeu de caractères est le contrôle qui compte, et il est délibérément une
+# liste blanche : cette valeur finit dans un fichier que lisent des unités
+# tournant en root. Un `$(…)`, un accent grave, une espace ou un guillemet
+# rescapé n'y ont rien à faire — les refuser ici ferme la voie par laquelle le
+# propriétaire du .env, qui n'est pas root, pousserait du contenu de son choix
+# vers un contexte root.
+# Une valeur vide est refusée pour une autre raison : elle produirait un fichier
+# syntaxiquement correct dont le seul effet serait de faire échouer chaque
+# alerte, au moment précis où on en a besoin.
+case "$dsn" in
   "") fail "SENTRY_CRON_DSN est absent ou vide dans $source_env" ;;
+  *[!A-Za-z0-9:/@._~%?=-]*)
+    fail "SENTRY_CRON_DSN de $source_env contient un caractère interdit"
+    ;;
+  https://*@*/* | http://*@*/*) ;;
   *) fail "SENTRY_CRON_DSN de $source_env n'a pas la forme d'un DSN Sentry" ;;
 esac
 

--- a/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
+++ b/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
@@ -14,14 +14,17 @@ umask 0077
 
 source_env="{{ alerting_dsn_source }}"
 target_env="{{ alerting_env_file }}"
+allowed_hosts="{{ alerting_dsn_allowed_hosts | join(' ') }}"
 
 fail() {
   printf 'SYNCHRONISATION DU DSN SENTRY IMPOSSIBLE : %s\n' "$1" >&2
   exit 1
 }
 
-if [ ! -r "$source_env" ]; then
-  fail "$source_env est absent ou illisible"
+# `-f` et pas seulement `-r` : un tube nommé déposé à cet emplacement par le
+# propriétaire du .env est lisible, et bloquerait cette tâche root indéfiniment.
+if [ ! -f "$source_env" ] || [ ! -r "$source_env" ]; then
+  fail "$source_env est absent, illisible, ou n'est pas un fichier ordinaire"
 fi
 
 # `sed` plutôt que `source` : le .env appartient à l'utilisateur de déploiement
@@ -77,6 +80,53 @@ case "$dsn" in
   https://*@*/* | http://*@*/*) ;;
   *) fail "SENTRY_CRON_DSN de $source_env n'a pas la forme d'un DSN Sentry" ;;
 esac
+
+# La validation ci-dessus porte sur la SYNTAXE. Il reste la DESTINATION, qui est
+# le vrai enjeu : ce DSN décide où partent les journaux d'unités root — mongod,
+# nginx, la sauvegarde — que le propriétaire du .env ne peut pas lire lui-même.
+# Le pointer vers un collecteur à soi, c'est à la fois exfiltrer ces journaux et
+# éteindre toute l'alerte derrière un puits qui répond 200, auto-contrôle
+# compris. Le contenu est traité comme hostile ; l'hôte doit l'être aussi.
+dsn_host="${dsn#*://}"
+dsn_host="${dsn_host#*@}"
+dsn_host="${dsn_host%%/*}"
+dsn_host="${dsn_host%%:*}"
+if [ -z "$dsn_host" ]; then
+  fail "SENTRY_CRON_DSN de $source_env ne comporte pas d'hôte"
+fi
+
+if [ -n "$allowed_hosts" ]; then
+  # Ancrage explicite : `alerting_dsn_allowed_hosts` est renseigné, l'hôte doit y
+  # figurer. C'est le réglage le plus sûr, à privilégier une fois l'hôte connu.
+  host_allowed=0
+  for allowed in $allowed_hosts; do
+    # shellcheck disable=SC2254 # motif glob voulu, pour autoriser « *.exemple.tld »
+    case "$dsn_host" in
+      $allowed)
+        host_allowed=1
+        break
+        ;;
+    esac
+  done
+  if [ "$host_allowed" -eq 0 ]; then
+    fail "hôte « $dsn_host » absent de alerting_dsn_allowed_hosts — refus de rediriger l'alerte"
+  fi
+elif [ -f "$target_env" ]; then
+  # Aucun ancrage déclaré : on épingle sur ce qui est déjà en place. Le premier
+  # passage adopte l'hôte du .env — sur un serveur en service, c'est le bon —, et
+  # tout changement ultérieur est refusé. Le DSN en place continue de fonctionner
+  # pendant ce temps : le refus ne coupe pas l'alerte, il la protège.
+  # Rotation légitime vers un autre hôte : renseigner alerting_dsn_allowed_hosts,
+  # ou supprimer le fichier cible pour ré-adopter.
+  current_host="$(sed -n 's/^SENTRY_DSN=//p' "$target_env" | tail -n 1)"
+  current_host="${current_host#*://}"
+  current_host="${current_host#*@}"
+  current_host="${current_host%%/*}"
+  current_host="${current_host%%:*}"
+  if [ -n "$current_host" ] && [ "$current_host" != "$dsn_host" ]; then
+    fail "changement d'hôte refusé : « $current_host » est en place, le .env propose « $dsn_host ». Renseigner alerting_dsn_allowed_hosts, ou supprimer $target_env pour ré-adopter."
+  fi
+fi
 
 candidate="$target_env.candidate"
 printf 'SENTRY_DSN=%s\n' "$dsn" >"$candidate"

--- a/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
+++ b/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
@@ -14,7 +14,7 @@ umask 0077
 
 source_env="{{ alerting_dsn_source }}"
 target_env="{{ alerting_env_file }}"
-allowed_hosts="{{ alerting_dsn_allowed_hosts | join(' ') }}"
+allowed_destinations="{{ alerting_dsn_allowed_destinations | join(' ') }}"
 
 fail() {
   printf 'SYNCHRONISATION DU DSN SENTRY IMPOSSIBLE : %s\n' "$1" >&2
@@ -84,48 +84,58 @@ esac
 # La validation ci-dessus porte sur la SYNTAXE. Il reste la DESTINATION, qui est
 # le vrai enjeu : ce DSN décide où partent les journaux d'unités root — mongod,
 # nginx, la sauvegarde — que le propriétaire du .env ne peut pas lire lui-même.
-# Le pointer vers un collecteur à soi, c'est à la fois exfiltrer ces journaux et
-# éteindre toute l'alerte derrière un puits qui répond 200, auto-contrôle
-# compris. Le contenu est traité comme hostile ; l'hôte doit l'être aussi.
-dsn_host="${dsn#*://}"
-dsn_host="${dsn_host#*@}"
-dsn_host="${dsn_host%%/*}"
-dsn_host="${dsn_host%%:*}"
-if [ -z "$dsn_host" ]; then
-  fail "SENTRY_CRON_DSN de $source_env ne comporte pas d'hôte"
+# Le pointer ailleurs, c'est à la fois exfiltrer ces journaux et éteindre toute
+# l'alerte derrière un puits qui répond 200, auto-contrôle compris.
+#
+# La destination, c'est l'hôte ET LE CHEMIN. S'arrêter à l'hôte ne ferme rien :
+# créer un second projet sur le même Sentry — mutualisé, auto-hébergé, ou un DSN
+# sans sous-domaine d'organisation — suffirait alors à tout détourner sans
+# changer un caractère de l'hôte. Seule la CLÉ reste libre : c'est le seul champ
+# qui doit pouvoir tourner.
+dsn_destination="${dsn#*://}"
+dsn_destination="${dsn_destination#*@}"
+if [ -z "$dsn_destination" ] || [ "$dsn_destination" = "$dsn" ]; then
+  fail "SENTRY_CRON_DSN de $source_env ne comporte pas de destination exploitable"
 fi
 
-if [ -n "$allowed_hosts" ]; then
-  # Ancrage explicite : `alerting_dsn_allowed_hosts` est renseigné, l'hôte doit y
-  # figurer. C'est le réglage le plus sûr, à privilégier une fois l'hôte connu.
-  host_allowed=0
-  for allowed in $allowed_hosts; do
-    # shellcheck disable=SC2254 # motif glob voulu, pour autoriser « *.exemple.tld »
-    case "$dsn_host" in
+if [ -n "$allowed_destinations" ]; then
+  # Ancrage explicite : `alerting_dsn_allowed_destinations` est renseigné, la
+  # destination doit y figurer. C'est le réglage le plus sûr, à privilégier dès
+  # que l'hôte et le projet sont connus.
+  destination_allowed=0
+  for allowed in $allowed_destinations; do
+    # shellcheck disable=SC2254 # motif glob voulu, pour autoriser « *.exemple.tld/4 »
+    case "$dsn_destination" in
       $allowed)
-        host_allowed=1
+        destination_allowed=1
         break
         ;;
     esac
   done
-  if [ "$host_allowed" -eq 0 ]; then
-    fail "hôte « $dsn_host » absent de alerting_dsn_allowed_hosts — refus de rediriger l'alerte"
+  if [ "$destination_allowed" -eq 0 ]; then
+    fail "destination « $dsn_destination » absente de alerting_dsn_allowed_destinations — refus de rediriger l'alerte"
   fi
 elif [ -f "$target_env" ]; then
-  # Aucun ancrage déclaré : on épingle sur ce qui est déjà en place. Le premier
-  # passage adopte l'hôte du .env — sur un serveur en service, c'est le bon —, et
-  # tout changement ultérieur est refusé. Le DSN en place continue de fonctionner
-  # pendant ce temps : le refus ne coupe pas l'alerte, il la protège.
-  # Rotation légitime vers un autre hôte : renseigner alerting_dsn_allowed_hosts,
-  # ou supprimer le fichier cible pour ré-adopter.
-  current_host="$(sed -n 's/^SENTRY_DSN=//p' "$target_env" | tail -n 1)"
-  current_host="${current_host#*://}"
-  current_host="${current_host#*@}"
-  current_host="${current_host%%/*}"
-  current_host="${current_host%%:*}"
-  if [ -n "$current_host" ] && [ "$current_host" != "$dsn_host" ]; then
-    fail "changement d'hôte refusé : « $current_host » est en place, le .env propose « $dsn_host ». Renseigner alerting_dsn_allowed_hosts, ou supprimer $target_env pour ré-adopter."
+  # Aucun ancrage déclaré : on épingle sur ce qui est déjà en place. Tout
+  # changement de destination est refusé, et le DSN en place continue de
+  # fonctionner pendant ce temps — le refus ne coupe pas l'alerte, il la protège.
+  # Rotation légitime : renseigner alerting_dsn_allowed_destinations, ou
+  # supprimer le fichier cible pour ré-adopter.
+  current_destination="$(sed -n 's/^SENTRY_DSN=//p' "$target_env" | tail -n 1)"
+  current_destination="${current_destination#*://}"
+  current_destination="${current_destination#*@}"
+  if [ -n "$current_destination" ] && [ "$current_destination" != "$dsn_destination" ]; then
+    fail "changement de destination refusé : « $current_destination » est en place, le .env propose « $dsn_destination ». Renseigner alerting_dsn_allowed_destinations, ou supprimer $target_env pour ré-adopter."
   fi
+else
+  # Ni liste blanche, ni destination déjà épinglée : il n'y a rien à quoi
+  # comparer. On adopte, mais on le DIT — l'adoption est signalée à part pour
+  # sortir en rouge côté ansible.
+  # Ce cas n'est pas théorique : `setup_alerting` tourne avant le
+  # provisionnement des applications, donc au tout premier bootstrap le .env
+  # n'existe pas encore et l'adoption n'a lieu qu'au passage suivant, quand
+  # l'utilisateur de déploiement tourne déjà.
+  adopted=1
 fi
 
 candidate="$target_env.candidate"
@@ -142,4 +152,8 @@ if cmp -s "$candidate" "$target_env"; then
 fi
 
 mv "$candidate" "$target_env"
-printf 'DSN mis à jour.\n'
+if [ "${adopted:-0}" -eq 1 ]; then
+  printf 'DSN adopté sans point de comparaison : %s\n' "$dsn_destination"
+else
+  printf 'DSN mis à jour.\n'
+fi

--- a/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
+++ b/roles/bootstrap/templates/alerting/sync_alerting_dsn.sh.j2
@@ -2,19 +2,37 @@
 # MANAGED BY MES AIDES OPS
 # Modifications should be made in templates/alerting/sync_alerting_dsn.sh.j2
 
-# Recopie le seul SENTRY_CRON_DSN du .env applicatif vers un fichier
-# d'environnement fermé (0600 root:root), d'où les unités d'alerte le liront.
+# Compose le DSN d'alerte et l'écrit dans un fichier d'environnement fermé
+# (0600 root:root), d'où les unités d'alerte le liront.
 #
-# Le DSN n'existe nulle part dans ce dépôt et ne transite par aucune variable
-# ansible : ce script tourne sur la machine, lit la valeur là où elle est déjà,
-# et ne l'affiche jamais.
+# LE POINT IMPORTANT DE CE SCRIPT : la destination — schéma, hôte, port, projet —
+# vient du DÉPÔT (`alerting_dsn_destination`, relu en revue de code). Du .env
+# applicatif, on ne prend QUE la clé publique, et on vérifie qu'elle est faite
+# uniquement de lettres et de chiffres.
+#
+# Ce découpage est structurel, pas défensif. Le .env appartient à l'utilisateur
+# de déploiement : tout ce qu'il contient est hostile par hypothèse. Tant qu'on
+# lisait la destination dedans, il fallait décider par comparaison de texte si
+# une URL fournie par un tiers pointait au bon endroit — et une comparaison
+# d'URL en shell se fait contourner : d'abord aucun ancrage, puis l'hôte sans le
+# chemin, puis un glob qui traverse la barre oblique. Ici il n'y a plus rien à
+# comparer. Une clé restreinte à [A-Za-z0-9] ne peut contenir ni « @ », ni « / »,
+# ni « : » : elle ne peut donc pas ajouter d'autorité ni de chemin, quoi qu'on
+# écrive dans le .env.
+#
+# Ce qui reste au propriétaire du .env : mettre une mauvaise clé, donc CASSER
+# l'alerte. Il ne peut plus la DÉTOURNER. C'est une réduction de la panne à
+# quelque chose de bruyant, que l'auto-contrôle et le balayage quotidien voient.
+#
+# La clé ne transite par aucune variable ansible et n'est jamais affichée.
 
 set -euo pipefail
 umask 0077
 
 source_env="{{ alerting_dsn_source }}"
 target_env="{{ alerting_env_file }}"
-allowed_destinations="{{ alerting_dsn_allowed_destinations | join(' ') }}"
+scheme="{{ alerting_dsn_scheme }}"
+destination="{{ alerting_dsn_destination }}"
 
 fail() {
   printf 'SYNCHRONISATION DU DSN SENTRY IMPOSSIBLE : %s\n' "$1" >&2
@@ -32,7 +50,7 @@ fi
 # root à quiconque peut écrire ce fichier, et importerait au passage tous les
 # autres secrets applicatifs dans l'environnement du processus.
 # La dernière affectation gagne, comme le ferait un interpréteur de .env.
-dsn="$(
+raw="$(
   sed -n \
     -e 's/^[[:space:]]*//' \
     -e 's/^export[[:space:]]\{1,\}//' \
@@ -47,96 +65,44 @@ trim() {
 # ORDRE IMPORTANT : les espaces de fin d'abord, les guillemets ensuite, puis de
 # nouveau les espaces qui étaient à l'intérieur des guillemets. Retirer les
 # guillemets en premier laisse le guillemet fermant collé à la valeur dès que la
-# ligne du .env se termine par une espace — invisible à la lecture, et le
-# fichier produit désarmerait alors chaque alerte sans que rien ne le signale.
-dsn="$(trim "$dsn")"
-case "$dsn" in
+# ligne du .env se termine par une espace — invisible à la lecture.
+raw="$(trim "$raw")"
+case "$raw" in
   \"*\")
-    dsn="${dsn%\"}"
-    dsn="${dsn#\"}"
+    raw="${raw%\"}"
+    raw="${raw#\"}"
     ;;
   \'*\')
-    dsn="${dsn%\'}"
-    dsn="${dsn#\'}"
+    raw="${raw%\'}"
+    raw="${raw#\'}"
     ;;
 esac
-dsn="$(trim "$dsn")"
+raw="$(trim "$raw")"
 
-# Contrôle de jeu de caractères et de forme, sans jamais afficher la valeur.
-# Le jeu de caractères est le contrôle qui compte, et il est délibérément une
-# liste blanche : cette valeur finit dans un fichier que lisent des unités
-# tournant en root. Un `$(…)`, un accent grave, une espace ou un guillemet
-# rescapé n'y ont rien à faire — les refuser ici ferme la voie par laquelle le
-# propriétaire du .env, qui n'est pas root, pousserait du contenu de son choix
-# vers un contexte root.
-# Une valeur vide est refusée pour une autre raison : elle produirait un fichier
-# syntaxiquement correct dont le seul effet serait de faire échouer chaque
-# alerte, au moment précis où on en a besoin.
-case "$dsn" in
-  "") fail "SENTRY_CRON_DSN est absent ou vide dans $source_env" ;;
-  *[!A-Za-z0-9:/@._~%?=-]*)
-    fail "SENTRY_CRON_DSN de $source_env contient un caractère interdit"
+if [ -z "$raw" ]; then
+  fail "SENTRY_CRON_DSN est absent ou vide dans $source_env"
+fi
+
+# Extraction de la seule clé publique. `%%@*` prend ce qui précède la PREMIÈRE
+# arobase : sur un DSN bien formé c'est la clé, et sur n'importe quoi d'autre le
+# résultat contiendra un caractère hors liste blanche et sera refusé juste après.
+# Aucune décision n'est prise à partir de ce qui suit — la destination, elle,
+# vient du dépôt.
+key="${raw#*://}"
+key="${key%%@*}"
+
+# Liste blanche stricte, sur un jeton simple et non sur une URL : c'est tout
+# l'intérêt du découpage. Une clé publique Sentry est alphanumérique.
+case "$key" in
+  "") fail "SENTRY_CRON_DSN de $source_env ne comporte pas de clé publique" ;;
+  *[!A-Za-z0-9]*)
+    fail "la clé publique de SENTRY_CRON_DSN ($source_env) contient un caractère interdit"
     ;;
-  https://*@*/* | http://*@*/*) ;;
-  *) fail "SENTRY_CRON_DSN de $source_env n'a pas la forme d'un DSN Sentry" ;;
 esac
 
-# La validation ci-dessus porte sur la SYNTAXE. Il reste la DESTINATION, qui est
-# le vrai enjeu : ce DSN décide où partent les journaux d'unités root — mongod,
-# nginx, la sauvegarde — que le propriétaire du .env ne peut pas lire lui-même.
-# Le pointer ailleurs, c'est à la fois exfiltrer ces journaux et éteindre toute
-# l'alerte derrière un puits qui répond 200, auto-contrôle compris.
-#
-# La destination, c'est l'hôte ET LE CHEMIN. S'arrêter à l'hôte ne ferme rien :
-# créer un second projet sur le même Sentry — mutualisé, auto-hébergé, ou un DSN
-# sans sous-domaine d'organisation — suffirait alors à tout détourner sans
-# changer un caractère de l'hôte. Seule la CLÉ reste libre : c'est le seul champ
-# qui doit pouvoir tourner.
-dsn_destination="${dsn#*://}"
-dsn_destination="${dsn_destination#*@}"
-if [ -z "$dsn_destination" ] || [ "$dsn_destination" = "$dsn" ]; then
-  fail "SENTRY_CRON_DSN de $source_env ne comporte pas de destination exploitable"
-fi
-
-if [ -n "$allowed_destinations" ]; then
-  # Ancrage explicite : `alerting_dsn_allowed_destinations` est renseigné, la
-  # destination doit y figurer. C'est le réglage le plus sûr, à privilégier dès
-  # que l'hôte et le projet sont connus.
-  destination_allowed=0
-  for allowed in $allowed_destinations; do
-    # shellcheck disable=SC2254 # motif glob voulu, pour autoriser « *.exemple.tld/4 »
-    case "$dsn_destination" in
-      $allowed)
-        destination_allowed=1
-        break
-        ;;
-    esac
-  done
-  if [ "$destination_allowed" -eq 0 ]; then
-    fail "destination « $dsn_destination » absente de alerting_dsn_allowed_destinations — refus de rediriger l'alerte"
-  fi
-elif [ -f "$target_env" ]; then
-  # Aucun ancrage déclaré : on épingle sur ce qui est déjà en place. Tout
-  # changement de destination est refusé, et le DSN en place continue de
-  # fonctionner pendant ce temps — le refus ne coupe pas l'alerte, il la protège.
-  # Rotation légitime : renseigner alerting_dsn_allowed_destinations, ou
-  # supprimer le fichier cible pour ré-adopter.
-  current_destination="$(sed -n 's/^SENTRY_DSN=//p' "$target_env" | tail -n 1)"
-  current_destination="${current_destination#*://}"
-  current_destination="${current_destination#*@}"
-  if [ -n "$current_destination" ] && [ "$current_destination" != "$dsn_destination" ]; then
-    fail "changement de destination refusé : « $current_destination » est en place, le .env propose « $dsn_destination ». Renseigner alerting_dsn_allowed_destinations, ou supprimer $target_env pour ré-adopter."
-  fi
-else
-  # Ni liste blanche, ni destination déjà épinglée : il n'y a rien à quoi
-  # comparer. On adopte, mais on le DIT — l'adoption est signalée à part pour
-  # sortir en rouge côté ansible.
-  # Ce cas n'est pas théorique : `setup_alerting` tourne avant le
-  # provisionnement des applications, donc au tout premier bootstrap le .env
-  # n'existe pas encore et l'adoption n'a lieu qu'au passage suivant, quand
-  # l'utilisateur de déploiement tourne déjà.
-  adopted=1
-fi
+# Composition, et non recopie : les trois morceaux sont assemblés ici, deux
+# venant du dépôt et un seul du .env.
+dsn="$scheme://$key@$destination"
 
 candidate="$target_env.candidate"
 printf 'SENTRY_DSN=%s\n' "$dsn" >"$candidate"
@@ -152,8 +118,4 @@ if cmp -s "$candidate" "$target_env"; then
 fi
 
 mv "$candidate" "$target_env"
-if [ "${adopted:-0}" -eq 1 ]; then
-  printf 'DSN adopté sans point de comparaison : %s\n' "$dsn_destination"
-else
-  printf 'DSN mis à jour.\n'
-fi
+printf 'DSN mis à jour.\n'

--- a/roles/bootstrap/templates/monitor/monitor-config.json.j2
+++ b/roles/bootstrap/templates/monitor/monitor-config.json.j2
@@ -1,1 +1,4 @@
-{ "applications": {{ applications|to_json(indent=4, sort_keys=True) }} }
+{
+  "applications": {{ applications | to_json(indent=4, sort_keys=True) }},
+  "units": {{ alerting_watched_units | to_json(indent=4, sort_keys=True) }}
+}

--- a/roles/bootstrap/templates/monitor/monitor-server.mjs
+++ b/roles/bootstrap/templates/monitor/monitor-server.mjs
@@ -1,5 +1,5 @@
 import { createServer } from "http"
-import { execSync, execFileSync } from "child_process"
+import { execFileSync } from "child_process"
 import configuration from "./monitor-config.json" with { type: "json" }
 
 const services = configuration.applications
@@ -13,9 +13,17 @@ const units = configuration.units
 const COMMAND_LIMITS = { timeout: 2000, killSignal: "SIGKILL" }
 
 function getDiskUsage() {
-  const command = "df | grep /$ | tr -s ' ' | cut -d ' ' -f 5 | tr -d '%'"
+  // Sans interpréteur de commandes : sur un pipeline lancé par un shell, le
+  // délai de garde ne tue que le shell et laisse les `df` derrière lui — ils
+  // s'accumulent alors à chaque requête, sur un point d'entrée public.
   try {
-    return execSync(command, COMMAND_LIMITS).toString().trim()
+    return execFileSync("df", ["--output=pcent", "/"], COMMAND_LIMITS)
+      .toString()
+      .trim()
+      .split("\n")
+      .pop()
+      .trim()
+      .replace("%", "")
   } catch (error) {
     console.error("An error occurred:", error)
     return "-"
@@ -93,10 +101,18 @@ function getUnitStates() {
       activeState,
       subState: properties.SubState,
       result: properties.Result,
+      // Liste blanche d'états sains, et non « tout sauf failed ». Un `oneshot`
+      // figé sur une connexion jamais répondue reste « activating », ce qui
+      // n'est pas un échec pour systemd : le déclarer vert ferait certifier par
+      // le témoin de dernier recours que tout va bien, précisément quand la
+      // chaîne d'alerte est morte. Une sauvegarde légitimement en cours apparaît
+      // donc aussi en non-vert le temps qu'elle tourne — c'est une information,
+      // pas une fausse alerte.
       ok:
         properties.LoadState === "loaded" &&
-        activeState !== "failed" &&
-        (!expectActive || activeState === "active"),
+        (expectActive
+          ? activeState === "active"
+          : activeState === "active" || activeState === "inactive"),
     }
   })
 }

--- a/roles/bootstrap/templates/monitor/monitor-server.mjs
+++ b/roles/bootstrap/templates/monitor/monitor-server.mjs
@@ -1,8 +1,9 @@
 import { createServer } from "http"
-import { execSync } from "child_process"
+import { execSync, execFileSync } from "child_process"
 import configuration from "./monitor-config.json" with { type: "json" }
 
 const services = configuration.applications
+const units = configuration.units
 
 function getDiskUsage() {
   const command = "df | grep /$ | tr -s ' ' | cut -d ' ' -f 5 | tr -d '%'"
@@ -12,6 +13,55 @@ function getDiskUsage() {
     console.error("An error occurred:", error)
     return "-"
   }
+}
+
+// Les sondes d'URL ci-dessous et les états d'unités ci-dessus n'attrapent pas
+// les mêmes pannes. Une unité qui redémarre en boucle sans jamais épuiser son
+// quota de redémarrages n'est ni `failed` ni absente : seule la requête HTTP la
+// voit. À l'inverse, une sauvegarde nocturne ou un timer supprimé n'exposent
+// aucune URL : seul l'état de l'unité en parle.
+function getUnitStates() {
+  return units.map(({ name, expect_active: expectActive }) => {
+    // execFileSync, sans passer par un interpréteur de commandes : le nom
+    // d'unité vient de l'inventaire, il n'a rien à faire dans un shell.
+    let properties
+    try {
+      properties = Object.fromEntries(
+        execFileSync("systemctl", [
+          "show",
+          name,
+          "--property=LoadState",
+          "--property=ActiveState",
+          "--property=SubState",
+          "--property=Result",
+        ])
+          .toString()
+          .trim()
+          .split("\n")
+          .map((line) => {
+            const separator = line.indexOf("=")
+            return [line.slice(0, separator), line.slice(separator + 1)]
+          })
+      )
+    } catch (error) {
+      console.error(`Error reading state of ${name}:`, error)
+      return { unit: name, expectActive, ok: false, error: String(error.message) }
+    }
+
+    const activeState = properties.ActiveState
+    return {
+      unit: name,
+      expectActive,
+      loadState: properties.LoadState,
+      activeState,
+      subState: properties.SubState,
+      result: properties.Result,
+      ok:
+        properties.LoadState === "loaded" &&
+        activeState !== "failed" &&
+        (!expectActive || activeState === "active"),
+    }
+  })
 }
 
 async function fetchURLStatus(url) {
@@ -30,6 +80,7 @@ const port = 8887
 createServer(async (req, res) => {
   const result = {
     diskUsagePercentage: await getDiskUsage(),
+    units: getUnitStates(),
     services: [],
   }
   for (const {

--- a/roles/bootstrap/templates/monitor/monitor-server.mjs
+++ b/roles/bootstrap/templates/monitor/monitor-server.mjs
@@ -3,7 +3,11 @@ import { execFileSync } from "child_process"
 import configuration from "./monitor-config.json" with { type: "json" }
 
 const services = configuration.applications
-const units = configuration.units
+// Repli sur une liste vide : ce fichier de configuration et ce serveur sont
+// posés par la même tâche ansible et bougent ensemble, mais une page de
+// supervision ne doit pas être ce qui tombe en premier quand quelque chose
+// cloche autour d'elle.
+const units = configuration.units ?? []
 
 // Toute commande lancée ici est synchrone et bloque la boucle d'événements pour
 // *toutes* les requêtes en cours : sans délai de garde, un `df` sur un montage
@@ -102,17 +106,20 @@ function getUnitStates() {
       subState: properties.SubState,
       result: properties.Result,
       // Liste blanche d'états sains, et non « tout sauf failed ». Un `oneshot`
-      // figé sur une connexion jamais répondue reste « activating », ce qui
-      // n'est pas un échec pour systemd : le déclarer vert ferait certifier par
-      // le témoin de dernier recours que tout va bien, précisément quand la
-      // chaîne d'alerte est morte. Une sauvegarde légitimement en cours apparaît
-      // donc aussi en non-vert le temps qu'elle tourne — c'est une information,
-      // pas une fausse alerte.
+      // figé reste « activating », ce qui n'est pas un échec pour systemd : le
+      // déclarer vert ferait certifier par le témoin de dernier recours que tout
+      // va bien, précisément quand la chaîne d'alerte est morte. Une sauvegarde
+      // légitimement en cours apparaît donc aussi en non-vert le temps qu'elle
+      // tourne — c'est une information, pas une fausse alerte.
+      // `reloading` est sain : c'est un état actif, celui d'un `systemctl reload
+      // nginx` en cours.
       ok:
         properties.LoadState === "loaded" &&
         (expectActive
-          ? activeState === "active"
-          : activeState === "active" || activeState === "inactive"),
+          ? activeState === "active" || activeState === "reloading"
+          : activeState === "active" ||
+            activeState === "reloading" ||
+            activeState === "inactive"),
     }
   })
 }
@@ -131,6 +138,30 @@ async function fetchURLStatus(url) {
 
 const port = 8887
 createServer(async (req, res) => {
+  // Le corps entier est protégé : le gestionnaire est `async`, donc toute
+  // exception non rattrapée devient une promesse rejetée, et sous Node >= 15 une
+  // promesse rejetée non gérée TUE le processus. Chaque requête relancerait
+  // alors la mise à mort, `Restart=on-failure` épuiserait son quota en quelques
+  // secondes, et la page finirait en `failed` permanent — soit exactement la
+  // panne d'un an que ce service est censé aider à repérer.
+  try {
+    // La charge utile est construite AVANT d'écrire l'en-tête : écrire 200 puis
+    // échouer rendrait un corps d'erreur sous un code de succès, qu'aucune sonde
+    // extérieure ne verrait passer.
+    const payload = JSON.stringify(await collectStatus(), null, 2)
+    res.writeHead(200, { "Content-Type": "application/json" })
+    res.write(payload)
+  } catch (error) {
+    console.error("Error building the status payload:", error)
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "application/json" })
+    }
+    res.write(JSON.stringify({ error: "status unavailable" }))
+  }
+  res.end()
+}).listen(port)
+
+async function collectStatus() {
   const result = {
     diskUsagePercentage: await getDiskUsage(),
     units: getUnitStates(),
@@ -173,9 +204,5 @@ createServer(async (req, res) => {
       status: await fetchURLStatus(openfiscaPublicUrl),
     })
   }
-  res.writeHead(200, {
-    "Content-Type": "application/json",
-  })
-  res.write(JSON.stringify(result, null, 2))
-  res.end()
-}).listen(port)
+  return result
+}

--- a/roles/bootstrap/templates/monitor/monitor-server.mjs
+++ b/roles/bootstrap/templates/monitor/monitor-server.mjs
@@ -5,49 +5,86 @@ import configuration from "./monitor-config.json" with { type: "json" }
 const services = configuration.applications
 const units = configuration.units
 
+// Toute commande lancée ici est synchrone et bloque la boucle d'événements pour
+// *toutes* les requêtes en cours : sans délai de garde, un `df` sur un montage
+// figé ou un systemd qui ne répond plus suffit à faire tomber la page, sur un
+// point d'entrée public et sans authentification, au moment précis où on en a
+// besoin. SIGKILL parce qu'un processus bloqué en E/S ignore SIGTERM.
+const COMMAND_LIMITS = { timeout: 2000, killSignal: "SIGKILL" }
+
 function getDiskUsage() {
   const command = "df | grep /$ | tr -s ' ' | cut -d ' ' -f 5 | tr -d '%'"
   try {
-    return execSync(command).toString().trim()
+    return execSync(command, COMMAND_LIMITS).toString().trim()
   } catch (error) {
     console.error("An error occurred:", error)
     return "-"
   }
 }
 
-// Les sondes d'URL ci-dessous et les états d'unités ci-dessus n'attrapent pas
-// les mêmes pannes. Une unité qui redémarre en boucle sans jamais épuiser son
-// quota de redémarrages n'est ni `failed` ni absente : seule la requête HTTP la
-// voit. À l'inverse, une sauvegarde nocturne ou un timer supprimé n'exposent
-// aucune URL : seul l'état de l'unité en parle.
+// Les états d'unités et les sondes d'URL plus bas n'attrapent pas les mêmes
+// pannes. Une unité qui redémarre en boucle sans jamais épuiser son quota de
+// redémarrages n'est ni `failed` ni absente : seule la requête HTTP la voit. À
+// l'inverse, une sauvegarde nocturne ou un timer supprimé n'exposent aucune URL :
+// seul l'état de l'unité en parle.
 function getUnitStates() {
-  return units.map(({ name, expect_active: expectActive }) => {
-    // execFileSync, sans passer par un interpréteur de commandes : le nom
-    // d'unité vient de l'inventaire, il n'a rien à faire dans un shell.
-    let properties
-    try {
-      properties = Object.fromEntries(
-        execFileSync("systemctl", [
+  const names = units.map(({ name }) => name)
+  // Un seul appel pour toutes les unités : autant d'appels que d'unités, c'est
+  // autant d'occasions de bloquer, et le délai de garde se cumulerait.
+  // execFileSync, sans interpréteur de commandes : les noms viennent de
+  // l'inventaire, ils n'ont rien à faire dans un shell.
+  let statesById
+  try {
+    statesById = Object.fromEntries(
+      execFileSync(
+        "systemctl",
+        [
           "show",
-          name,
+          ...names,
+          "--property=Id",
           "--property=LoadState",
           "--property=ActiveState",
           "--property=SubState",
           "--property=Result",
-        ])
-          .toString()
-          .trim()
-          .split("\n")
-          .map((line) => {
-            const separator = line.indexOf("=")
-            return [line.slice(0, separator), line.slice(separator + 1)]
-          })
+        ],
+        COMMAND_LIMITS
       )
-    } catch (error) {
-      console.error(`Error reading state of ${name}:`, error)
-      return { unit: name, expectActive, ok: false, error: String(error.message) }
-    }
+        .toString()
+        .trim()
+        // systemd sépare les unités par une ligne vide.
+        .split("\n\n")
+        .map((block) => {
+          const properties = Object.fromEntries(
+            block
+              .split("\n")
+              .filter((line) => line.includes("="))
+              .map((line) => {
+                const separator = line.indexOf("=")
+                return [line.slice(0, separator), line.slice(separator + 1)]
+              })
+          )
+          return [properties.Id, properties]
+        })
+    )
+  } catch (error) {
+    // Le détail part dans le journal du service, pas dans la réponse : cette
+    // page est anonyme, elle n'a pas à relayer la sortie d'erreur d'un
+    // processus système.
+    console.error("Error reading systemd unit states:", error)
+    return units.map(({ name, expect_active: expectActive }) => ({
+      unit: name,
+      expectActive,
+      ok: false,
+      error: "systemd unit state unavailable",
+    }))
+  }
 
+  return units.map(({ name, expect_active: expectActive }) => {
+    const properties = statesById[name]
+    if (!properties) {
+      console.error(`No state returned by systemctl for ${name}`)
+      return { unit: name, expectActive, ok: false, error: "no state returned" }
+    }
     const activeState = properties.ActiveState
     return {
       unit: name,


### PR DESCRIPTION
## Pourquoi

**Rien ne signale qu'un service est en échec.** Deux preuves, découvertes cette semaine :

- `monitor_service` — le service de supervision lui-même — est resté en échec **pendant un an**. Sa page de statut publique renvoyait 502. On ne l'a su qu'en tapant `systemctl --failed` à la main.
- La sauvegarde MongoDB de #240 échoue bruyamment (code non nul, unité en `failed`, journal explicite), mais personne n'en est averti. Une sauvegarde qui échoue en silence pendant un mois est le mode de défaillance qui fait vraiment mal.

## Le raisonnement

`OnFailure=` réagit à une **transition** ; une page de statut lit un **état**. Nos deux pannes ne sont pas du même genre : la sauvegarde qui échoue est une transition, `monitor_service` mort un an est un état. La transition avait bien eu lieu — un jour, une fois — et n'avait servi à personne.

D'où les deux moitiés, complémentaires et non redondantes :

1. **`OnFailure=`** sur les unités surveillées, pour l'immédiateté.
2. **Un balayage quotidien** (timer systemd, 08h15) qui lit `systemctl --failed` en entier et pousse vers Sentry — c'est lui qui aurait attrapé `monitor_service`.

La page de supervision est conservée mais **ramenée à son rôle réel** : surface d'inspection humaine, pas canal d'alerte. Elle gagne au passage un rôle propre — une unité qui **redémarre en boucle** sans épuiser son quota n'est ni `failed` ni absente ; seule une sonde HTTP la voit.

**Courriel écarté** : exim4 est là, mais personne n'a vérifié qu'il délivre vers l'extérieur, il faudrait choisir un destinataire, et l'équipe a déjà Sentry pour les échecs cron. Un canal de plus est un canal de moins surveillé.

## Le DSN ne transite par aucune variable ansible

Le déploiement est une **commande SSH forcée** qui lance `ansible-playbook --connection=local` sur le serveur (`scripts/update_ops.sh`) : il n'existe aucun canal d'`--extra-vars`, donc ni secret GitHub ni vault — sauf à déposer un mot de passe de vault sur la machine, ce qui ne résout rien.

Le DSN est donc extrait **sur la cible**, depuis le `.env` applicatif, vers `/etc/aides-jeunes/alerting.env` en 0600 root:root. Un script sur cible fait l'extraction et ne rend que « changé / inchangé » — la valeur n'apparaît dans aucune sortie ansible.

Copier plutôt que lire directement, pour deux raisons techniques : les unités portent `ProtectHome=true` et **ne peuvent pas** lire `/home` (démontré) ; et un service root qui sourcerait un fichier possédé par l'utilisateur de déploiement offrirait une exécution de code en root à qui peut l'écrire.

## Preuves

Conteneur Debian 12, systemd en PID 1, vrai `sentry-cli` 3.6.2, DSN factice pointant sur un collecteur HTTP local. Rejouable.

- **Échec réel** : `mongodb-backup.service` — le vrai, templé par son rôle — part et échoue → `OnFailure=` → requête `POST /api/1/envelope/` capturée, avec `fingerprint: ['systemd-unit-failure','mongodb-backup.service']`, les tags unité/instance/hôte, l'état systemd en `extra`, et les lignes de journal en fil d'Ariane.
- **Nominal** : balayage complet → « aucune unité en défaut », **0 requête**. Idem après réparation. Pas de bruit à ignorer.
- **Panne déjà installée** (le cas `monitor_service`) : le balayage la retrouve. Unité simplement arrêtée : « attendue active, état « inactive » ».
- **Réflexivité** : collecteur coupé → `sentry-cli` sort en 1 → l'unité d'alerte passe elle-même en `failed` → **le balayage suivant la remonte**.
- **Idempotence** : `changed=19` puis `changed=0`, tâche de synchronisation du DSN comprise.
- `ansible-lint --offline` : **0 échec, 0 avertissement sur 68 fichiers**, profil `production`. `shellcheck` propre, `systemd-analyze verify` sans erreur.

## ⚠️ Ce que ça ne couvre pas — à lire avant de merger

- **Personne n'est réveillé.** Les événements atterrissent dans Sentry comme les échecs cron. **Si ce projet Sentry n'a pas de règle d'alerte, on remplace un silence par une ligne dans une interface web.** Créer la règle sur l'empreinte `systemd-unit-failure` est l'autre moitié du travail, et elle est chez vous.
- **Sentry est un point unique** : DSN faux, quota plein, réseau coupé → rien n'arrive. Bruyant localement, muet à distance.
- **Balayage désactivé** = plus rien, et il ne le dira pas. Seul témoin restant : la page de statut.
- **Redémarrage en boucle lent** : invisible pour systemd, rattrapé seulement par la sonde HTTP.
- Retirer une unité de la liste **ne supprime pas** son greffon `/etc/systemd/system/<unité>.d/50-onfailure.conf`.
- Les états d'unités sont publiés sur une page **sans authentification** : la liste est restreinte, et le `systemctl --failed` complet n'y figure jamais.

## Non vérifié

- **Rien n'a tourné sur equinoxe.** Je n'ai pas confirmé que `/home/main/aides_jeunes/repository/.env` y contient bien `SENTRY_CRON_DSN`. S'il manque, le play affiche un avertissement et continue — testé.
- **Le premier déploiement enverra une salve** si des unités sont déjà en échec sur la machine. C'est voulu, mais attendez-vous à des tickets le jour du merge.
- `nginx.service` et `mongod.service` sont dans la liste par défaut mais absents du conteneur de test ; le greffon est identique et posé de la même façon.

## Lié

La fuite du DSN dans les journaux, trouvée en construisant ceci, est isolée dans #242 — elle mérite de partir seule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)