### PR TITLE
fix(mongodb): prouve la complétude de la sauvegarde et sérialise les exécutions

### DIFF
--- a/roles/bootstrap/defaults/main.yaml
+++ b/roles/bootstrap/defaults/main.yaml
@@ -43,3 +43,21 @@ mongodb_backup_retention_days: 14
 # d'octets : sans ce seuil, une faute de frappe dans le nom d'une base
 # produirait des sauvegardes vides pendant des mois sans un seul signal.
 mongodb_backup_min_archive_bytes: 4096
+# Complétude du contenu. Le script compte les documents de chaque collection
+# juste avant le dump et confronte ce relevé au compte rendu de mongodump : une
+# collection supprimée pendant que mongodump traite les autres produit une
+# archive intègre et bien formée, mais amputée. Une collection non vide qui
+# ressort à zéro est toujours refusée ; ce taux ne porte que sur le total de la
+# base, pour absorber les suppressions légitimes survenues pendant le dump sans
+# laisser passer une perte de masse. 90 % : `tools:cleaner` efface chaque jour à
+# 05h00, bien après la sauvegarde de 03h30, et les suppressions faites par les
+# usagers pendant les quelques minutes du dump se comptent sur les doigts.
+mongodb_backup_min_document_ratio_percent: 90
+# Filet grossier contre l'effondrement, comparé à la plus grosse archive encore
+# conservée — pas à une constante, qui ne détecte que la base absente.
+# Volontairement large : le contrôle fin est le recomptage des documents
+# ci-dessus, celui-ci ne couvre que ce qui lui échapperait (une base tronquée
+# côté mongod, un disque qui se remplit). Un seuil serré crierait sur les
+# variations légitimes — une campagne d'anonymisation, une purge — et une alerte
+# qui crie pour rien finit ignorée.
+mongodb_backup_min_size_ratio_percent: 50

--- a/roles/bootstrap/tasks/setup_mongodb_backup.yaml
+++ b/roles/bootstrap/tasks/setup_mongodb_backup.yaml
@@ -8,10 +8,15 @@
 # les fichiers statiques) et hors du dépôt ops synchronisé dans /opt/mes-aides.
 # 0700 root:root : les archives contiennent la base complète, données
 # personnelles et financières comprises.
+# follow: false — le confinement systemd de l'unité (ReadWritePaths) résout les
+# liens symboliques : un lien à cet emplacement ferait écrire les archives dans
+# sa cible. Le script refuse ce cas de son côté ; ici on s'assure qu'Ansible ne
+# fabrique ni n'entérine un lien.
 - name: Create MongoDB backup directory
   ansible.builtin.file:
     path: "{{ mongodb_backup_directory }}"
     state: directory
+    follow: false
     owner: root
     group: root
     mode: "0700"
@@ -29,7 +34,6 @@
     owner: root
     group: root
     mode: "0644"
-  notify: Reload systemd
 - name: Setup MongoDB backup timer
   ansible.builtin.template:
     src: templates/mongodb-backup.timer.j2
@@ -37,14 +41,14 @@
     owner: root
     group: root
     mode: "0644"
-  notify: Reload systemd
-# Le gestionnaire de rechargement est différé jusqu'au prochain point de
-# synchronisation : sans ce drapeau, systemd travaillerait sur les anciennes
-# définitions d'unités.
-- name: Reload systemd before enabling the timer
-  ansible.builtin.meta: flush_handlers
+# daemon_reload porté par la tâche elle-même : le module recharge les
+# définitions avant d'agir sur l'unité, sans rapporter de changement pour
+# autant. Un handler serait différé après l'activation du timer, et le forcer
+# par `meta: flush_handlers` viderait toute la file — dont le redémarrage de
+# nginx notifié plus tôt, qui partirait avant l'écriture de ses configurations.
 - name: Enable and start MongoDB backup timer
   ansible.builtin.systemd:
     name: "{{ mongodb_backup_service_name }}.timer"
     enabled: true
     state: started
+    daemon_reload: true

--- a/roles/bootstrap/templates/mongodb-backup.service.j2
+++ b/roles/bootstrap/templates/mongodb-backup.service.j2
@@ -14,9 +14,35 @@ Group=root
 UMask=0077
 ExecStart={{ mongodb_backup_script_path }}
 
-# Le service n'a besoin d'écrire que dans le répertoire des sauvegardes. Le
-# reste du système lui est en lecture seule : une erreur de configuration ne
-# peut pas déposer d'archive sous /var/www ni dans un dépôt applicatif.
+# PIÈGE : mongosh range sa configuration sous $HOME/.mongodb et, s'il n'y
+# parvient pas, écrit un avertissement sur sa sortie *standard* en sortant
+# malgré tout en 0 — l'avertissement se mêle alors aux données demandées.
+# `ProtectHome` ci-dessous remplace /root par un répertoire vide et
+# inaccessible : sans un HOME accessible, l'inventaire des collections est
+# illisible et *chaque* exécution du service échoue.
+#
+# Ce foyer est un répertoire d'exécution à nous, créé en 0700 root au démarrage
+# et détruit à la fin — et non /tmp, qui n'est privé que tant que `PrivateTmp`
+# est là. Si cette directive sautait un jour pour une raison sans rapport,
+# n'importe quel utilisateur local pourrait poser un lien symbolique à la place
+# du fichier de configuration de mongosh et obtenir une écriture root
+# arbitraire. La sûreté ne doit pas dépendre d'une seconde directive.
+RuntimeDirectory=mongodb-backup
+RuntimeDirectoryMode=0700
+Environment=HOME=/run/mongodb-backup
+
+# `Type=oneshot` n'impose aucun délai de garde. Un mongodump figé sur un socket
+# retiendrait le verrou indéfiniment et empêcherait toutes les sauvegardes
+# suivantes, sans que rien ne passe en `failed`. Une heure : la sauvegarde de
+# production se compte en minutes.
+TimeoutStartSec=3600
+
+# Le service n'a besoin d'écrire que dans le répertoire des sauvegardes ; le
+# reste du système lui est monté en lecture seule.
+# PIÈGE : ReadWritePaths résout les liens symboliques. Si le chemin ci-dessous
+# devenait un lien, systemd ouvrirait sa cible en écriture — /var/www par
+# exemple — sans rien signaler. Le refus est dans le script, qui contrôle que le
+# répertoire de sauvegarde n'est pas un lien.
 ProtectSystem=strict
 ReadWritePaths={{ mongodb_backup_directory }}
 ProtectHome=true

--- a/roles/bootstrap/templates/mongodb_backup.sh.j2
+++ b/roles/bootstrap/templates/mongodb_backup.sh.j2
@@ -12,6 +12,14 @@
 
 set -euo pipefail
 
+# `[!0-9]`, plus bas, est un intervalle de *collation* et non une classe ASCII :
+# sous une locale UTF-8, les chiffres arabo-indiens, devanagari ou pleine chasse
+# y tombent et franchissent la validation des entiers, pour échouer ensuite dans
+# une comparaison arithmétique qui sort en 2 — un code que `if` lit comme
+# « faux ». La locale C ferme cette porte et rend au passage `sort`, `find` et
+# `awk` déterministes, quelle que soit la configuration de la machine.
+export LC_ALL=C
+
 # Les archives contiennent la base complète : données personnelles et
 # financières. Tout ce que ce script crée n'est lisible que par root.
 umask 0077
@@ -21,6 +29,8 @@ mongo_host="{{ mongodb_backup_host }}"
 mongo_port="{{ mongodb_backup_port }}"
 retention_days="{{ mongodb_backup_retention_days }}"
 min_archive_bytes="{{ mongodb_backup_min_archive_bytes }}"
+min_document_ratio_percent="{{ mongodb_backup_min_document_ratio_percent }}"
+min_size_ratio_percent="{{ mongodb_backup_min_size_ratio_percent }}"
 databases=({% for database in mongodb_backup_databases %}"{{ database }}" {% endfor %})
 
 fail() {
@@ -28,15 +38,43 @@ fail() {
   exit 1
 }
 
-if [ ! -d "$backup_dir" ]; then
-  fail "le répertoire de sauvegarde $backup_dir n'existe pas"
-fi
+# `[ abc -lt 1 ]` sort en code 2, que `if` interprète comme « faux » et que
+# `set -e` ne voit pas dans une condition : une valeur non numérique passerait
+# tous les tests arithmétiques puis ferait mourir le script plus loin — ou pire,
+# le ferait réussir sur une rétention absurde. Le filtrage sur les caractères
+# précède donc toute comparaison.
+#
+# Le zéro initial est refusé plutôt que toléré : `$((030 - 1))` vaut 23, l'octal
+# de bash. La rétention deviendrait silencieusement fausse, sans la moindre
+# erreur — et YAML 1.1 fabrique volontiers un `030` dans un inventaire. Au-delà
+# de 18 chiffres l'entier de bash déborde et les comparaisons se mettent à
+# mentir ; la longueur se contrôle par un motif, la syntaxe bash de la longueur
+# d'une variable accolant une accolade et un dièse que Jinja lit comme une
+# ouverture de commentaire.
+require_integer_in_range() {
+  local name="$1" value="$2" minimum="$3" maximum="$4"
+  case "$value" in
+    '' | *[!0-9]* | 0?*)
+      fail "$name doit être un entier positif sans zéro initial, valeur reçue : « $value »"
+      ;;
+    ???????????????????*)
+      fail "$name dépasse la capacité entière du script, valeur reçue : « $value »"
+      ;;
+  esac
+  if [ "$value" -lt "$minimum" ] || [ "$value" -gt "$maximum" ]; then
+    fail "$name doit être compris entre $minimum et $maximum, valeur reçue : $value"
+  fi
+}
 
-if [ "$retention_days" -lt 1 ]; then
-  fail "rétention invalide ($retention_days jours) : au moins 1 jour est requis"
-fi
+require_integer_in_range "la rétention (en jours)" "$retention_days" 1 3650
+require_integer_in_range "le plancher de taille d'archive (en octets)" "$min_archive_bytes" 1 1099511627776
+require_integer_in_range "le taux minimal de documents sauvegardés (en %)" "$min_document_ratio_percent" 1 100
+require_integer_in_range "le taux minimal de taille d'archive (en %)" "$min_size_ratio_percent" 1 100
 
-for tool in mongodump mongorestore gzip; do
+# mongosh sert à inventorier les collections et leur nombre de documents juste
+# avant le dump : c'est ce qui permet de constater l'amputation d'une
+# collection. Il est installé par le paquet `mongodb-org`, qui en dépend.
+for tool in mongodump mongorestore mongosh gzip flock; do
   command -v "$tool" >/dev/null ||
     fail "$tool est introuvable, impossible de sauvegarder ou de vérifier"
 done
@@ -48,6 +86,39 @@ if [ -z "${databases[*]}" ]; then
   fail "aucune base à sauvegarder : mongodb_backup_databases est vide"
 fi
 
+# `ReadWritePaths` de l'unité systemd résout les liens symboliques : si
+# $backup_dir en devenait un, le confinement autoriserait l'écriture dans sa
+# cible — /var/www par exemple — sans rien signaler. Le refus est ici.
+if [ -L "$backup_dir" ]; then
+  fail "le répertoire de sauvegarde $backup_dir est un lien symbolique : refus d'écrire des archives ailleurs que dans un vrai répertoire dédié"
+fi
+
+# Sous systemd ce test ne peut pas échouer : `ReadWritePaths` exige que le
+# chemin existe et l'unité meurt en 226/NAMESPACE avant même l'ExecStart. Il ne
+# sert qu'aux lancements directs du script, hors unité.
+if [ ! -d "$backup_dir" ]; then
+  fail "le répertoire de sauvegarde $backup_dir n'existe pas"
+fi
+
+# systemd refuse de démarrer deux fois la même unité, mais rien n'empêche un
+# lancement manuel pendant la fenêtre du timer. Sans verrou, le balayage des
+# fichiers de travail au début d'une exécution détruit le dump en cours de
+# l'autre, voire son archive déjà vérifiée. Le fichier de verrou est caché, et
+# les balayages comme la rotation ne retiennent que des noms en `.archive.gz` :
+# ni le verrou ni le journal de dump ne peuvent être ramassés.
+exec {backup_lock}>"$backup_dir/.lock"
+flock --nonblock "$backup_lock" ||
+  fail "une sauvegarde est déjà en cours (verrou $backup_dir/.lock) : cette exécution s'arrête sans rien modifier"
+
+# Journal de mongodump, relu pour recompter les documents effectivement écrits.
+# Caché lui aussi, et supprimé quoi qu'il arrive.
+dump_report="$backup_dir/.mongodb-backup.report"
+trap 'rm -f "$dump_report"' EXIT
+
+# LIMITE CONNUE : à la seconde près. Deux exécutions lancées dans la même
+# seconde publieraient le même nom et la seconde écraserait la première par son
+# `mv`. Hors de portée du timer, qui déclenche une fois par jour, et le verrou
+# ci-dessus sérialise de toute façon les lancements manuels.
 timestamp="$(date +%Y%m%dT%H%M%S)"
 
 # Un arrêt brutal pendant un dump laisse un fichier de travail que rien ne
@@ -65,24 +136,158 @@ for database in "${databases[@]}"; do
 
   printf 'Sauvegarde de %s depuis %s:%s\n' "$database" "$mongo_host" "$mongo_port"
 
+  # Inventaire de référence, pris juste avant le dump : nom de chaque collection
+  # et nombre exact de documents. C'est la seule mesure prise hors de mongodump,
+  # donc la seule capable de contredire ce qu'il annonce. `countDocuments` sur
+  # un filtre vide se résout par un parcours d'index sur _id, négligeable devant
+  # la lecture intégrale que mongodump fait juste après.
+  #
+  # PORTÉE : `type: "collection"` écarte les vues et les collections
+  # temporelles, que mongodump sauvegarde sous `system.buckets.*` — elles sont
+  # bien archivées, mais hors du recomptage. Aucune dans les bases sauvegardées
+  # à ce jour ; le jour où il y en aura, ce contrôle sera à étendre.
+  if ! inventory="$(mongosh \
+    --host "$mongo_host" \
+    --port "$mongo_port" \
+    --quiet \
+    "$database" \
+    --eval '
+      db.getCollectionInfos({ type: "collection" })
+        .map(function (info) { return info.name })
+        .filter(function (name) { return name.indexOf("system.") !== 0 })
+        .sort()
+        .forEach(function (name) {
+          print(name + "\t" + db.getCollection(name).countDocuments({}))
+        })
+    ')"; then
+    fail "impossible d'inventorier les collections de $database sur $mongo_host:$mongo_port (cause ci-dessus)"
+  fi
+
+  if [ -z "$inventory" ]; then
+    fail "$database ne contient aucune collection sur $mongo_host:$mongo_port : base inexistante ou mal nommée ?"
+  fi
+
   # Aucun identifiant sur la ligne de commande : mongod n'écoute que sur la
   # boucle locale et n'a pas d'authentification. Ajouter --username/--password
   # ici les exposerait dans `ps` et dans le journal — passer par --config si
   # l'authentification est un jour activée.
-  if ! mongodump \
+  #
+  # Le compte rendu de mongodump — une ligne par collection, avec le nombre de
+  # documents écrits — arrive sur la sortie d'erreur. Il est détourné vers un
+  # fichier pour être relu plus bas, puis recopié tel quel dans le journal du
+  # service.
+  dump_status=0
+  mongodump \
     --host="$mongo_host" \
     --port="$mongo_port" \
     --db="$database" \
     --gzip \
-    --archive="$partial"; then
+    --archive="$partial" \
+    2>"$dump_report" || dump_status=$?
+  cat "$dump_report" >&2
+  if [ "$dump_status" -ne 0 ]; then
     rm -f "$partial"
-    fail "mongodump a échoué pour $database sur $mongo_host:$mongo_port (cause ci-dessus)"
+    fail "mongodump a échoué pour $database sur $mongo_host:$mongo_port (code $dump_status, cause ci-dessus)"
   fi
 
   size="$(stat --format=%s "$partial")"
   if [ "$size" -lt "$min_archive_bytes" ]; then
     rm -f "$partial"
     fail "archive de $database anormalement petite ($size octets, plancher $min_archive_bytes) : base vide, inexistante ou mal nommée ?"
+  fi
+
+  # Filet grossier contre l'effondrement : la plus grosse archive de la fenêtre
+  # de rétention sert de référence. Volontairement large — le contrôle fin est
+  # le recomptage des documents ci-dessous ; ce seuil-ci n'est là que pour ce
+  # qui lui échapperait, et ne doit jamais crier sur une variation légitime.
+  #
+  # `-mtime` borne la fenêtre, et cette borne est essentielle : la rotation
+  # n'ayant lieu qu'après un succès, une référence anormalement grosse se
+  # perpétuerait toute seule — elle fait échouer, l'échec empêche la rotation,
+  # l'absence de rotation la préserve. Ainsi bornée, elle sort de la comparaison
+  # au plus tard au bout de $retention_days jours.
+  #
+  # Le prix de ce bornage : après une interruption plus longue que la rétention,
+  # plus aucune référence, donc plus de filet — au moment précis où l'on en
+  # aurait le plus besoin. Le contournement est donc annoncé, jamais silencieux.
+  reference_size="$(find "$backup_dir" -maxdepth 1 -type f -name "$database-*.archive.gz" -mtime "-$retention_days" -printf '%s\n' | sort -n | tail -1)"
+  if [ -z "$reference_size" ]; then
+    printf 'Aucune archive de référence de %s dans la fenêtre de %s jours : contrôle de taille relatif ignoré\n' \
+      "$database" "$retention_days"
+  elif [ "$((size * 100))" -lt "$((reference_size * min_size_ratio_percent))" ]; then
+    rm -f "$partial"
+    fail "archive de $database à $size octets contre $reference_size pour la plus grosse archive de la fenêtre (moins de $min_size_ratio_percent %) : dump probablement amputé"
+  fi
+
+  # PIÈGE : ni `gzip --test` ni `mongorestore --dryRun` ne disent quoi que ce
+  # soit du *contenu*. Une collection supprimée pendant que mongodump traite les
+  # autres produit une archive intègre, bien formée, et amputée : mongodump
+  # annonce « 0 documents » pour cette collection et sort en 0. Seule la
+  # confrontation à l'inventaire pris avant le dump le révèle.
+  unset dumped_documents
+  declare -A dumped_documents=()
+  while IFS=$'\t' read -r namespace count; do
+    collection="${namespace#"$database."}"
+    dumped_documents["$collection"]="$count"
+  done < <(awk '
+    /done dumping / {
+      entry = $0
+      sub(/^.*done dumping /, "", entry)
+      gsub(/`/, "", entry)
+      if (match(entry, /\([0-9]+ documents?\)[ \t]*$/)) {
+        namespace = substr(entry, 1, RSTART - 1)
+        sub(/[ \t]+$/, "", namespace)
+        count = substr(entry, RSTART + 1)
+        sub(/[^0-9].*$/, "", count)
+        print namespace "\t" count
+      }
+    }
+  ' "$dump_report")
+
+  anomalies=""
+  expected_total=0
+  dumped_total=0
+  while IFS=$'\t' read -r collection expected; do
+    [ -n "$collection" ] || continue
+    # L'inventaire ne doit rien contenir d'autre que « collection<TAB>nombre ».
+    # Une ligne mal formée signifie que mongosh a mêlé un message à sa sortie —
+    # avertissement d'obsolescence, plainte TLS, refus d'écrire sa configuration
+    # — et non qu'une collection manque. Sans ce contrôle, le message serait pris
+    # pour un nom de collection et le script accuserait la sauvegarde d'être
+    # incomplète : un échec bruyant, mais qui désigne le mauvais coupable.
+    case "$expected" in
+      '' | *[!0-9]*)
+        fail "ligne d'inventaire illisible pour $database : « $collection / $expected » — mongosh a écrit un message parmi ses résultats, ou une collection porte une tabulation dans son nom"
+        ;;
+    esac
+    expected_total="$((expected_total + expected))"
+    dumped="${dumped_documents[$collection]-}"
+    if [ -z "$dumped" ]; then
+      anomalies="$anomalies"$'\n'"  - $collection : absente de l'archive alors qu'elle contenait $expected documents"
+      continue
+    fi
+    dumped_total="$((dumped_total + dumped))"
+    # Tolérance zéro sur une collection vidée : elle rejetterait aussi une petite
+    # collection légitimement vidée pendant le dump. Le cas ne se présente pas
+    # ici — `tools:cleaner` modifie les documents en place et n'en supprime
+    # aucun —, et refuser une archive de trop vaut mieux qu'en garder une amputée.
+    if [ "$expected" -gt 0 ] && [ "$dumped" -eq 0 ]; then
+      anomalies="$anomalies"$'\n'"  - $collection : $expected documents avant le dump, aucun dans l'archive"
+    fi
+  done <<<"$inventory"
+
+  # Comparaison globale plutôt que collection par collection : les suppressions
+  # légitimes pendant le dump touchent quelques documents, noyés dans le total,
+  # alors qu'une perte massive s'y voit. Un total sauvegardé supérieur à
+  # l'inventaire est normal — des documents ont été créés pendant le dump.
+  if [ "$expected_total" -gt 0 ] &&
+    [ "$((dumped_total * 100))" -lt "$((expected_total * min_document_ratio_percent))" ]; then
+    anomalies="$anomalies"$'\n'"  - $dumped_total documents sauvegardés pour $expected_total comptés avant le dump (moins de $min_document_ratio_percent %)"
+  fi
+
+  if [ -n "$anomalies" ]; then
+    rm -f "$partial"
+    fail "l'archive de $database est incomplète, elle a été supprimée plutôt que conservée :$anomalies"
   fi
 
   # Relit l'archive entière et contrôle les sommes CRC et les longueurs de
@@ -111,11 +316,17 @@ for database in "${databases[@]}"; do
   fi
 
   mv "$partial" "$final"
-  printf 'Archive vérifiée : %s (%s octets)\n' "$final" "$size"
+  printf 'Archive vérifiée : %s (%s octets, %s documents sur %s inventoriés)\n' \
+    "$final" "$size" "$dumped_total" "$expected_total"
 done
 
 # La rotation n'a lieu qu'après une sauvegarde réussie : une série d'échecs ne
 # doit jamais consommer les archives encore valides.
+#
+# LIMITE CONNUE : `-mtime` compare à l'heure courante, et une archive dont la
+# date de modification est dans le futur — horloge déréglée, restauration
+# maladroite — n'est jamais retenue. Elle survivrait à la rétention sans un mot,
+# ce qui est d'abord un problème RGPD : ces archives ne sont pas anonymisées.
 printf 'Rotation : suppression des archives de plus de %s jours\n' "$retention_days"
 find "$backup_dir" \
   -maxdepth 1 \


### PR DESCRIPTION
Corrige des défauts trouvés par revue adversariale sur la sauvegarde **déjà déployée** (#240). Ouverte en brouillon : revue adversariale en cours sur ce correctif lui-même.

## Le contrôle de complétude ne prouvait rien

#240 affirmait que le service « échoue bruyamment plutôt que de laisser croire à une sauvegarde ». **Faux pour l'amputation logique** : une collection supprimée pendant le dump donne `mongodump rc=0`, et les trois contrôles passent.

Et le remède évident ne marche pas non plus. Mesuré sur 6 collections et 385 000 documents, `b_followups` supprimée en cours de dump :

```
done dumping `db_multi.b_followups` (0 documents)
Archive vérifiée : … (222334334 octets)   rc=0
222334334 / 222730770 = 99.82 %
```

**L'archive amputée pèse 99,8 % de la précédente.** Un seuil à la moitié, à 90 %, à 99 % : aucun ne la rejette. Une collection perdue ne se voit pas dans les octets.

### Contrôle retenu : recomptage des documents

Le script inventorie collections et documents avec `mongosh` juste avant le dump, puis confronte ce relevé au compte rendu de `mongodump` :

- **règle dure** — une collection non vide qui ressort à zéro, ou absente du compte rendu, est toujours refusée ;
- **règle proportionnelle** — le total sauvegardé doit atteindre 90 % de l'inventaire, appliquée au **total de la base** pour que les suppressions légitimes pendant le dump ne déclenchent rien.

```
ÉCHEC : l'archive de db_multi est incomplète, elle a été supprimée plutôt que conservée :
  - b_followups : 5000 documents avant le dump, aucun dans l'archive        rc=1

ÉCHEC : 330000 documents sauvegardés pour 385000 comptés avant le dump      rc=1
```

Le seuil de taille est **conservé à 50 %**, en filet secondaire paramétrable, comparé à la plus grosse archive gardée. Il attrape ce qui échappe au recomptage — testé à documents constants, charges utiles vidées : `9967758 octets contre 222733625 (moins de 50 %)`. La moitié est le bon compromis **parce que** ce n'est plus le contrôle principal : plus serré, il crierait sur une anonymisation ou une purge, et une alerte qui crie pour rien finit ignorée.

## Rétention : deux valeurs faisaient mentir le script

Au-delà des cas connus (`abc`, `-3`), deux valeurs sortaient en **`rc=0`** :

- **`retention_days=""`** → `-mtime "+-1"`, que GNU find accepte et qui matche **tout** : le script **supprime toutes les archives, y compris celle qu'il vient de créer**, puis affiche « Sauvegarde MongoDB terminée. ». Vérifié, répertoire vidé.
- **`retention_days="1.5"`** → erreur d'arithmétique, rotation jamais exécutée, `rc=0`.

Un filtrage `case ''|*[!0-9]*` couvre les cinq cas, et s'applique aux trois seuils numériques.

## `meta: flush_handlers` tirait le redémarrage de nginx en plein milieu du rôle

C'était le seul `flush_handlers` du rôle, et il est **global**. Reproduit sur le rôle réel :

| déployé | corrigé |
|---|---|
| timer → flush → **`RUNNING HANDLER [Restart nginx]`** → activation → certbot, sites | activation → certbot, sites → **`RUNNING HANDLER [Restart nginx]`** |

**La tâche `daemon_reload` séparée n'a pas été retenue** : elle rapporte `changed` à chaque exécution et casse l'idempotence. `daemon_reload: true` est porté par la tâche d'activation du timer — le module recharge avant d'agir et ne compte pas ce rechargement comme un changement. Prouvé : `OnCalendar` modifié est lu dans la même exécution, sans `daemon-reload` manuel. Idempotence `ok=15 changed=0`, 0 handler au second passage.

## Deux exécutions se détruisaient mutuellement

Déployé : `RUN1 rc=1`, `stat: cannot statx …`, RUN2 publie — et dans un autre entrelacement l'archive vérifiée du gagnant est détruite après avoir passé tous les contrôles.

Corrigé par `flock` : `RUN2 rc=1 — une sauvegarde est déjà en cours`, RUN1 `rc=0`, archives antérieures intactes. Le `.lock` et le journal de dump sont cachés et survivent à la rotation.

## Lien symbolique

`ReadWritePaths` **résout les liens** : répertoire remplacé par un lien vers `/var/www` → archive de 222 Mo déposée sous `/var/www`, `rc=0`, et Ansible applique `0700 root:root` à la cible. Le commentaire de l'unité promettait l'inverse.

Corrigé des deux côtés : le script refuse (`rc=1`), Ansible échoue proprement (`already exists as a link`, `changed=0`), et le commentaire dit désormais la vérité.

## Vérifié

`ansible-lint --offline` identique à `181c140` (seul échec préexistant : `ansible.posix.authorized_key`) ; avec les collections en chemin local, **0 échec 0 avertissement**, profil `production`. `bash -n` et `shellcheck -s bash` propres. Sauvegarde nominale passante, **y compris la toute première** (répertoire vide, aucune référence de taille) : `385000 documents sur 385000 inventoriés`. Contrôles d'intégrité non régressés : archive tronquée et archive d'un octet modifié toujours rejetées. Analyse du compte rendu testée sur les deux formats de `mongodump`, le singulier « 1 document » et les lignes de progression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)